### PR TITLE
feat: capture hints on result screen

### DIFF
--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -10,6 +10,7 @@
 // @match        *://*.geoguessr.com/*
 // @require      https://raw.githubusercontent.com/miraclewhips/geoguessr-event-framework/5e449d6b64c828fce5d2915772d61c7f95263e34/geoguessr-event-framework.js
 // @connect      learnablemeta.com
+// @connect      kacuunztbvznzhfsyfgp.supabase.co
 // @grant        GM_addStyle
 // @grant        GM_getValue
 // @grant        GM_info
@@ -20,11 +21,23 @@
 // @run-at       document-start
 // ==/UserScript==
 
-(e=>{if(typeof GM_addStyle=="function"){GM_addStyle(e);return}const o=document.createElement("style");o.textContent=e,document.head.append(o)})(` .loadership_ZOJAQ.svelte-i1jlc0{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-i1jlc0-loadership_ZOJAQ_scale 1.2s infinite,svelte-i1jlc0-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-i1jlc0-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-i1jlc0-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-7lhsry{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-fofh7f{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-fofh7f{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-fofh7f{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-fofh7f{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-fofh7f{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-fofh7f{left:0}.next-area.svelte-fofh7f{right:0}.prev.svelte-fofh7f,.next.svelte-fofh7f{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-fofh7f{left:0}.next.svelte-fofh7f{right:0}.indicators.svelte-fofh7f{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-fofh7f{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-fofh7f{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-a3mhc8{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100);padding:6px 10px;border-radius:5px;font-size:17px;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-a3mhc8>.header:where(.svelte-a3mhc8){margin-top:0}.geometa-footer.svelte-a3mhc8{color:#d3d3d3;font-size:small}.announcement.svelte-a3mhc8{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-a3mhc8{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-a3mhc8:hover,.vote-close-btn.svelte-a3mhc8:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-a3mhc8{color:#188bd2}a.svelte-a3mhc8:hover{text-decoration:underline}.skill-icons--discord.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-a3mhc8{display:inline-block;vertical-align:middle}.flex.svelte-a3mhc8{display:flex;align-items:center}.icons.svelte-a3mhc8 a:where(.svelte-a3mhc8) span:where(.svelte-a3mhc8){align-items:center;justify-content:center}hr.svelte-a3mhc8{border:0;border-top:1px solid white;width:100%}.header.svelte-a3mhc8{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-a3mhc8{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-a3mhc8{background:var(--ds-color-purple-100);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-a3mhc8 p:where(.svelte-a3mhc8){margin:0 0 10px;font-size:17px}.modal-url.svelte-a3mhc8{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-a3mhc8{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-a3mhc8{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-a3mhc8:hover{background:#0056b3}.close-btn.svelte-a3mhc8{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-a3mhc8:hover{background:#d3d3d3;color:var(--ds-color-purple-100)}button.svelte-a3mhc8{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-a3mhc8{animation:svelte-a3mhc8-blink-animation 1s infinite}.help-message.svelte-a3mhc8{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:#007bff;font-weight:700}@keyframes svelte-a3mhc8-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1mmcvqu{background-color:#0003;color:#fff;text-align:center;z-index:999999;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px;text-shadow:0 0 10px rgba(255,255,255,.1)}p.svelte-1mmcvqu{font-size:14px;font-weight:700}button.svelte-1mmcvqu{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-1rq8lsd{z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-1rq8lsd{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-1rq8lsd{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-1rq8lsd{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-1rq8lsd{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-message.svelte-1rq8lsd{flex-grow:1;margin-right:10px}.toast-close-button.svelte-1rq8lsd{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-1rq8lsd:hover{opacity:1}.custom-yellow-button.svelte-17or0cf{background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-17or0cf:hover:not(:where(.svelte-17or0cf):disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-17or0cf:active:not(:where(.svelte-17or0cf):disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-17or0cf:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-17or0cf:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.modal-overlay.svelte-17or0cf{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-17or0cf{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-17or0cf h2:where(.svelte-17or0cf){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf){margin-bottom:15px;line-height:1.6}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf){color:#007bff;text-decoration:underline}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf):hover{color:#0056b3}.modal-input.svelte-17or0cf{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-17or0cf{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-17or0cf{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-17or0cf{background-color:#28a745;color:#fff}.modal-button-save.svelte-17or0cf:hover{background-color:#218838}.modal-button-cancel.svelte-17or0cf{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-17or0cf:hover{background-color:#5a6268}.modal-note.svelte-17or0cf{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
+(e=>{if(typeof GM_addStyle=="function"){GM_addStyle(e);return}const o=document.createElement("style");o.textContent=e,document.head.append(o)})(` .loadership_ZOJAQ.svelte-i1jlc0{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-i1jlc0-loadership_ZOJAQ_scale 1.2s infinite,svelte-i1jlc0-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-i1jlc0-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-i1jlc0-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-7lhsry{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-fofh7f{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-fofh7f{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-fofh7f{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-fofh7f{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-fofh7f{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-fofh7f{left:0}.next-area.svelte-fofh7f{right:0}.prev.svelte-fofh7f,.next.svelte-fofh7f{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-fofh7f{left:0}.next.svelte-fofh7f{right:0}.indicators.svelte-fofh7f{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-fofh7f{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-fofh7f{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-a3mhc8{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100);padding:6px 10px;border-radius:5px;font-size:17px;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-a3mhc8>.header:where(.svelte-a3mhc8){margin-top:0}.geometa-footer.svelte-a3mhc8{color:#d3d3d3;font-size:small}.announcement.svelte-a3mhc8{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-a3mhc8{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-a3mhc8:hover,.vote-close-btn.svelte-a3mhc8:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-a3mhc8{color:#188bd2}a.svelte-a3mhc8:hover{text-decoration:underline}.skill-icons--discord.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-a3mhc8{display:inline-block;vertical-align:middle}.flex.svelte-a3mhc8{display:flex;align-items:center}.icons.svelte-a3mhc8 a:where(.svelte-a3mhc8) span:where(.svelte-a3mhc8){align-items:center;justify-content:center}hr.svelte-a3mhc8{border:0;border-top:1px solid white;width:100%}.header.svelte-a3mhc8{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-a3mhc8{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-a3mhc8{background:var(--ds-color-purple-100);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-a3mhc8 p:where(.svelte-a3mhc8){margin:0 0 10px;font-size:17px}.modal-url.svelte-a3mhc8{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-a3mhc8{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-a3mhc8{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-a3mhc8:hover{background:#0056b3}.close-btn.svelte-a3mhc8{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-a3mhc8:hover{background:#d3d3d3;color:var(--ds-color-purple-100)}button.svelte-a3mhc8{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-a3mhc8{animation:svelte-a3mhc8-blink-animation 1s infinite}.help-message.svelte-a3mhc8{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:#007bff;font-weight:700}@keyframes svelte-a3mhc8-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.hint-panel.svelte-rfbclr{position:fixed;bottom:1rem;right:1rem;background:#444;color:#fff;padding:.5rem;border:1px solid #ccc;border-radius:4px;z-index:9999;box-shadow:0 2px 6px #0003;max-width:300px}.hint-panel.svelte-rfbclr input:where(.svelte-rfbclr),.hint-panel.svelte-rfbclr textarea:where(.svelte-rfbclr){width:100%;margin-bottom:.25rem;color:#000;background:#fff}.hint-panel.svelte-rfbclr .error:where(.svelte-rfbclr){color:#f88;font-size:.8rem;margin-bottom:.25rem}.hint-panel.svelte-rfbclr header:where(.svelte-rfbclr){display:flex;justify-content:space-between;align-items:center;margin-bottom:.25rem}.hint-panel.svelte-rfbclr button.close:where(.svelte-rfbclr){background:transparent;border:none;cursor:pointer;color:#fff}.geometa-map-label-container.svelte-1mmcvqu{background-color:#0003;color:#fff;text-align:center;z-index:999999;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px;text-shadow:0 0 10px rgba(255,255,255,.1)}p.svelte-1mmcvqu{font-size:14px;font-weight:700}button.svelte-1mmcvqu{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-1rq8lsd{z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-1rq8lsd{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-1rq8lsd{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-1rq8lsd{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-1rq8lsd{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-message.svelte-1rq8lsd{flex-grow:1;margin-right:10px}.toast-close-button.svelte-1rq8lsd{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-1rq8lsd:hover{opacity:1}.custom-yellow-button.svelte-17or0cf{background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-17or0cf:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-17or0cf:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-17or0cf:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-17or0cf:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.modal-overlay.svelte-17or0cf{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-17or0cf{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-17or0cf h2:where(.svelte-17or0cf){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf){margin-bottom:15px;line-height:1.6}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf){color:#007bff;text-decoration:underline}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf):hover{color:#0056b3}.modal-input.svelte-17or0cf{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-17or0cf{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-17or0cf{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-17or0cf{background-color:#28a745;color:#fff}.modal-button-save.svelte-17or0cf:hover{background-color:#218838}.modal-button-cancel.svelte-17or0cf{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-17or0cf:hover{background-color:#5a6268}.modal-note.svelte-17or0cf{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
 
 (async function () {
   'use strict';
 
+  var __defProp = Object.defineProperty;
+  var __typeError = (msg) => {
+    throw TypeError(msg);
+  };
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  var __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg);
+  var __privateGet = (obj, member, getter) => (__accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj));
+  var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+  var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), member.set(obj, value), value);
+  var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
+  var _current, _previous, _callbacks, _pending, _deferred, _neutered, _async_effects, _boundary_async_effects, _render_effects, _effects, _block_effects, _Batch_instances, process_fn, traverse_effect_tree_fn, commit_fn, _a;
   var _GM_getValue = /* @__PURE__ */ (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = /* @__PURE__ */ (() => typeof GM_info != "undefined" ? GM_info : void 0)();
   var _GM_registerMenuCommand = /* @__PURE__ */ (() => typeof GM_registerMenuCommand != "undefined" ? GM_registerMenuCommand : void 0)();
@@ -177,6 +190,7 @@
   }
   const DEV = false;
   var is_array = Array.isArray;
+  var index_of = Array.prototype.indexOf;
   var array_from = Array.from;
   var define_property = Object.defineProperty;
   var get_descriptor = Object.getOwnPropertyDescriptor;
@@ -184,6 +198,7 @@
   var object_prototype = Object.prototype;
   var array_prototype = Array.prototype;
   var get_prototype_of = Object.getPrototypeOf;
+  var is_extensible = Object.isExtensible;
   function is_function(thing) {
     return typeof thing === "function";
   }
@@ -200,26 +215,124 @@
       arr[i]();
     }
   }
+  function deferred() {
+    var resolve;
+    var reject;
+    var promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
   const DERIVED = 1 << 1;
   const EFFECT = 1 << 2;
   const RENDER_EFFECT = 1 << 3;
   const BLOCK_EFFECT = 1 << 4;
   const BRANCH_EFFECT = 1 << 5;
   const ROOT_EFFECT = 1 << 6;
-  const UNOWNED = 1 << 7;
-  const DISCONNECTED = 1 << 8;
-  const CLEAN = 1 << 9;
-  const DIRTY = 1 << 10;
-  const MAYBE_DIRTY = 1 << 11;
-  const INERT = 1 << 12;
-  const DESTROYED = 1 << 13;
-  const EFFECT_RAN = 1 << 14;
-  const EFFECT_TRANSPARENT = 1 << 15;
-  const LEGACY_DERIVED_PROP = 1 << 16;
+  const BOUNDARY_EFFECT = 1 << 7;
+  const UNOWNED = 1 << 8;
+  const DISCONNECTED = 1 << 9;
+  const CLEAN = 1 << 10;
+  const DIRTY = 1 << 11;
+  const MAYBE_DIRTY = 1 << 12;
+  const INERT = 1 << 13;
+  const DESTROYED = 1 << 14;
+  const EFFECT_RAN = 1 << 15;
+  const EFFECT_TRANSPARENT = 1 << 16;
+  const INSPECT_EFFECT = 1 << 17;
   const HEAD_EFFECT = 1 << 18;
-  const EFFECT_HAS_DERIVED = 1 << 19;
+  const EFFECT_PRESERVED = 1 << 19;
+  const USER_EFFECT = 1 << 20;
+  const REACTION_IS_UPDATING = 1 << 21;
+  const ASYNC = 1 << 22;
+  const ERROR_VALUE = 1 << 23;
   const STATE_SYMBOL = Symbol("$state");
+  const LEGACY_PROPS = Symbol("legacy props");
   const LOADING_ATTR_SYMBOL = Symbol("");
+  const STALE_REACTION = new class StaleReactionError extends Error {
+    constructor() {
+      super(...arguments);
+      __publicField(this, "name", "StaleReactionError");
+      __publicField(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
+    }
+  }();
+  function await_outside_boundary() {
+    {
+      throw new Error(`https://svelte.dev/e/await_outside_boundary`);
+    }
+  }
+  function lifecycle_outside_component(name) {
+    {
+      throw new Error(`https://svelte.dev/e/lifecycle_outside_component`);
+    }
+  }
+  function async_derived_orphan() {
+    {
+      throw new Error(`https://svelte.dev/e/async_derived_orphan`);
+    }
+  }
+  function effect_in_teardown(rune) {
+    {
+      throw new Error(`https://svelte.dev/e/effect_in_teardown`);
+    }
+  }
+  function effect_in_unowned_derived() {
+    {
+      throw new Error(`https://svelte.dev/e/effect_in_unowned_derived`);
+    }
+  }
+  function effect_orphan(rune) {
+    {
+      throw new Error(`https://svelte.dev/e/effect_orphan`);
+    }
+  }
+  function effect_update_depth_exceeded() {
+    {
+      throw new Error(`https://svelte.dev/e/effect_update_depth_exceeded`);
+    }
+  }
+  function props_invalid_value(key) {
+    {
+      throw new Error(`https://svelte.dev/e/props_invalid_value`);
+    }
+  }
+  function state_descriptors_fixed() {
+    {
+      throw new Error(`https://svelte.dev/e/state_descriptors_fixed`);
+    }
+  }
+  function state_prototype_fixed() {
+    {
+      throw new Error(`https://svelte.dev/e/state_prototype_fixed`);
+    }
+  }
+  function state_unsafe_mutation() {
+    {
+      throw new Error(`https://svelte.dev/e/state_unsafe_mutation`);
+    }
+  }
+  const EACH_ITEM_REACTIVE = 1;
+  const EACH_INDEX_REACTIVE = 1 << 1;
+  const EACH_IS_CONTROLLED = 1 << 2;
+  const EACH_IS_ANIMATED = 1 << 3;
+  const EACH_ITEM_IMMUTABLE = 1 << 4;
+  const PROPS_IS_IMMUTABLE = 1;
+  const PROPS_IS_RUNES = 1 << 1;
+  const PROPS_IS_UPDATED = 1 << 2;
+  const PROPS_IS_BINDABLE = 1 << 3;
+  const PROPS_IS_LAZY_INITIAL = 1 << 4;
+  const TRANSITION_IN = 1;
+  const TRANSITION_OUT = 1 << 1;
+  const TRANSITION_GLOBAL = 1 << 2;
+  const TEMPLATE_FRAGMENT = 1;
+  const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
+  const UNINITIALIZED = Symbol();
+  const NAMESPACE_HTML = "http://www.w3.org/1999/xhtml";
+  let hydrating = false;
+  function reset(node) {
+    return;
+  }
   function equals(value) {
     return value === this.v;
   }
@@ -229,117 +342,807 @@
   function safe_equals(value) {
     return !safe_not_equal(value, this.v);
   }
-  function effect_in_teardown(rune) {
-    {
-      throw new Error("effect_in_teardown");
+  let async_mode_flag = false;
+  let legacy_mode_flag = false;
+  let tracing_mode_flag = false;
+  function enable_legacy_mode_flag() {
+    legacy_mode_flag = true;
+  }
+  let component_context = null;
+  function set_component_context(context) {
+    component_context = context;
+  }
+  function push(props, runes = false, fn) {
+    component_context = {
+      p: component_context,
+      c: null,
+      e: null,
+      s: props,
+      x: null,
+      l: legacy_mode_flag && !runes ? { s: null, u: null, $: [] } : null
+    };
+  }
+  function pop(component) {
+    var context = (
+      /** @type {ComponentContext} */
+      component_context
+    );
+    var effects = context.e;
+    if (effects !== null) {
+      context.e = null;
+      for (var fn of effects) {
+        create_user_effect(fn);
+      }
+    }
+    component_context = context.p;
+    return (
+      /** @type {T} */
+      {}
+    );
+  }
+  function is_runes() {
+    return !legacy_mode_flag || component_context !== null && component_context.l === null;
+  }
+  const adjustments = /* @__PURE__ */ new WeakMap();
+  function handle_error(error) {
+    var effect2 = active_effect;
+    if (effect2 === null) {
+      active_reaction.f |= ERROR_VALUE;
+      return error;
+    }
+    if ((effect2.f & EFFECT_RAN) === 0) {
+      if ((effect2.f & BOUNDARY_EFFECT) === 0) {
+        if (!effect2.parent && error instanceof Error) {
+          apply_adjustments(error);
+        }
+        throw error;
+      }
+      effect2.b.error(error);
+    } else {
+      invoke_error_boundary(error, effect2);
     }
   }
-  function effect_in_unowned_derived() {
-    {
-      throw new Error("effect_in_unowned_derived");
+  function invoke_error_boundary(error, effect2) {
+    while (effect2 !== null) {
+      if ((effect2.f & BOUNDARY_EFFECT) !== 0) {
+        try {
+          effect2.b.error(error);
+          return;
+        } catch (e) {
+          error = e;
+        }
+      }
+      effect2 = effect2.parent;
+    }
+    if (error instanceof Error) {
+      apply_adjustments(error);
+    }
+    throw error;
+  }
+  function apply_adjustments(error) {
+    const adjusted = adjustments.get(error);
+    if (adjusted) {
+      define_property(error, "message", {
+        value: adjusted.message
+      });
+      define_property(error, "stack", {
+        value: adjusted.stack
+      });
     }
   }
-  function effect_orphan(rune) {
-    {
-      throw new Error("effect_orphan");
+  let micro_tasks = [];
+  let idle_tasks = [];
+  function run_micro_tasks() {
+    var tasks = micro_tasks;
+    micro_tasks = [];
+    run_all(tasks);
+  }
+  function run_idle_tasks() {
+    var tasks = idle_tasks;
+    idle_tasks = [];
+    run_all(tasks);
+  }
+  function queue_micro_task(fn) {
+    if (micro_tasks.length === 0) {
+      queueMicrotask(run_micro_tasks);
+    }
+    micro_tasks.push(fn);
+  }
+  function flush_tasks() {
+    if (micro_tasks.length > 0) {
+      run_micro_tasks();
+    }
+    if (idle_tasks.length > 0) {
+      run_idle_tasks();
     }
   }
-  function effect_update_depth_exceeded() {
-    {
-      throw new Error("effect_update_depth_exceeded");
+  function get_pending_boundary() {
+    var boundary = (
+      /** @type {Effect} */
+      active_effect.b
+    );
+    while (boundary !== null && !boundary.has_pending_snippet()) {
+      boundary = boundary.parent;
+    }
+    if (boundary === null) {
+      await_outside_boundary();
+    }
+    return boundary;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function derived(fn) {
+    var flags = DERIVED | DIRTY;
+    var parent_derived = active_reaction !== null && (active_reaction.f & DERIVED) !== 0 ? (
+      /** @type {Derived} */
+      active_reaction
+    ) : null;
+    if (active_effect === null || parent_derived !== null && (parent_derived.f & UNOWNED) !== 0) {
+      flags |= UNOWNED;
+    } else {
+      active_effect.f |= EFFECT_PRESERVED;
+    }
+    const signal = {
+      ctx: component_context,
+      deps: null,
+      effects: null,
+      equals,
+      f: flags,
+      fn,
+      reactions: null,
+      rv: 0,
+      v: (
+        /** @type {V} */
+        UNINITIALIZED
+      ),
+      wv: 0,
+      parent: parent_derived ?? active_effect,
+      ac: null
+    };
+    return signal;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function async_derived(fn, location2) {
+    let parent = (
+      /** @type {Effect | null} */
+      active_effect
+    );
+    if (parent === null) {
+      async_derived_orphan();
+    }
+    var boundary = (
+      /** @type {Boundary} */
+      parent.b
+    );
+    var promise = (
+      /** @type {Promise<V>} */
+      /** @type {unknown} */
+      void 0
+    );
+    var signal = source(
+      /** @type {V} */
+      UNINITIALIZED
+    );
+    var prev2 = null;
+    var should_suspend = !active_reaction;
+    async_effect(() => {
+      try {
+        var p = fn();
+      } catch (error) {
+        p = Promise.reject(error);
+      }
+      var r2 = () => p;
+      promise = (prev2 == null ? void 0 : prev2.then(r2, r2)) ?? Promise.resolve(p);
+      prev2 = promise;
+      var batch = (
+        /** @type {Batch} */
+        current_batch
+      );
+      var pending = boundary.pending;
+      if (should_suspend) {
+        boundary.update_pending_count(1);
+        if (!pending) batch.increment();
+      }
+      const handler = (value, error = void 0) => {
+        prev2 = null;
+        if (!pending) batch.activate();
+        if (error) {
+          if (error !== STALE_REACTION) {
+            signal.f |= ERROR_VALUE;
+            internal_set(signal, error);
+          }
+        } else {
+          if ((signal.f & ERROR_VALUE) !== 0) {
+            signal.f ^= ERROR_VALUE;
+          }
+          internal_set(signal, value);
+        }
+        if (should_suspend) {
+          boundary.update_pending_count(-1);
+          if (!pending) batch.decrement();
+        }
+        unset_context();
+      };
+      promise.then(handler, (e) => handler(null, e || "unknown"));
+      if (batch) {
+        return () => {
+          queueMicrotask(() => batch.neuter());
+        };
+      }
+    });
+    return new Promise((fulfil) => {
+      function next2(p) {
+        function go() {
+          if (p === promise) {
+            fulfil(signal);
+          } else {
+            next2(promise);
+          }
+        }
+        p.then(go, go);
+      }
+      next2(promise);
+    });
+  }
+  // @__NO_SIDE_EFFECTS__
+  function derived_safe_equal(fn) {
+    const signal = /* @__PURE__ */ derived(fn);
+    signal.equals = safe_equals;
+    return signal;
+  }
+  function destroy_derived_effects(derived2) {
+    var effects = derived2.effects;
+    if (effects !== null) {
+      derived2.effects = null;
+      for (var i = 0; i < effects.length; i += 1) {
+        destroy_effect(
+          /** @type {Effect} */
+          effects[i]
+        );
+      }
     }
   }
-  function props_invalid_value(key) {
+  function get_derived_parent_effect(derived2) {
+    var parent = derived2.parent;
+    while (parent !== null) {
+      if ((parent.f & DERIVED) === 0) {
+        return (
+          /** @type {Effect} */
+          parent
+        );
+      }
+      parent = parent.parent;
+    }
+    return null;
+  }
+  function execute_derived(derived2) {
+    var value;
+    var prev_active_effect = active_effect;
+    set_active_effect(get_derived_parent_effect(derived2));
     {
-      throw new Error("props_invalid_value");
+      try {
+        destroy_derived_effects(derived2);
+        value = update_reaction(derived2);
+      } finally {
+        set_active_effect(prev_active_effect);
+      }
+    }
+    return value;
+  }
+  function update_derived(derived2) {
+    var value = execute_derived(derived2);
+    if (!derived2.equals(value)) {
+      derived2.v = value;
+      derived2.wv = increment_write_version();
+    }
+    if (is_destroying_effect) return;
+    if (batch_deriveds !== null) {
+      batch_deriveds.set(derived2, derived2.v);
+    } else {
+      var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
+      set_signal_status(derived2, status);
     }
   }
-  function state_descriptors_fixed() {
-    {
-      throw new Error("state_descriptors_fixed");
+  function flatten(sync, async, fn) {
+    const d = is_runes() ? derived : derived_safe_equal;
+    if (async.length === 0) {
+      fn(sync.map(d));
+      return;
+    }
+    var batch = current_batch;
+    var parent = (
+      /** @type {Effect} */
+      active_effect
+    );
+    var restore = capture();
+    var boundary = get_pending_boundary();
+    Promise.all(async.map((expression) => /* @__PURE__ */ async_derived(expression))).then((result) => {
+      batch == null ? void 0 : batch.activate();
+      restore();
+      try {
+        fn([...sync.map(d), ...result]);
+      } catch (error) {
+        if ((parent.f & DESTROYED) === 0) {
+          invoke_error_boundary(error, parent);
+        }
+      }
+      batch == null ? void 0 : batch.deactivate();
+      unset_context();
+    }).catch((error) => {
+      boundary.error(error);
+    });
+  }
+  function capture() {
+    var previous_effect = active_effect;
+    var previous_reaction = active_reaction;
+    var previous_component_context = component_context;
+    return function restore() {
+      set_active_effect(previous_effect);
+      set_active_reaction(previous_reaction);
+      set_component_context(previous_component_context);
+    };
+  }
+  function unset_context() {
+    set_active_effect(null);
+    set_active_reaction(null);
+    set_component_context(null);
+  }
+  const batches = /* @__PURE__ */ new Set();
+  let current_batch = null;
+  let batch_deriveds = null;
+  let effect_pending_updates = /* @__PURE__ */ new Set();
+  let queued_root_effects = [];
+  let last_scheduled_effect = null;
+  let is_flushing = false;
+  const _Batch = class _Batch {
+    constructor() {
+      __privateAdd(this, _Batch_instances);
+      /**
+       * The current values of any sources that are updated in this batch
+       * They keys of this map are identical to `this.#previous`
+       * @type {Map<Source, any>}
+       */
+      __privateAdd(this, _current, /* @__PURE__ */ new Map());
+      /**
+       * The values of any sources that are updated in this batch _before_ those updates took place.
+       * They keys of this map are identical to `this.#current`
+       * @type {Map<Source, any>}
+       */
+      __privateAdd(this, _previous, /* @__PURE__ */ new Map());
+      /**
+       * When the batch is committed (and the DOM is updated), we need to remove old branches
+       * and append new ones by calling the functions added inside (if/each/key/etc) blocks
+       * @type {Set<() => void>}
+       */
+      __privateAdd(this, _callbacks, /* @__PURE__ */ new Set());
+      /**
+       * The number of async effects that are currently in flight
+       */
+      __privateAdd(this, _pending, 0);
+      /**
+       * A deferred that resolves when the batch is committed, used with `settled()`
+       * TODO replace with Promise.withResolvers once supported widely enough
+       * @type {{ promise: Promise<void>, resolve: (value?: any) => void, reject: (reason: unknown) => void } | null}
+       */
+      __privateAdd(this, _deferred, null);
+      /**
+       * True if an async effect inside this batch resolved and
+       * its parent branch was already deleted
+       */
+      __privateAdd(this, _neutered, false);
+      /**
+       * Async effects (created inside `async_derived`) encountered during processing.
+       * These run after the rest of the batch has updated, since they should
+       * always have the latest values
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _async_effects, []);
+      /**
+       * The same as `#async_effects`, but for effects inside a newly-created
+       * `<svelte:boundary>` — these do not prevent the batch from committing
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _boundary_async_effects, []);
+      /**
+       * Template effects and `$effect.pre` effects, which run when
+       * a batch is committed
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _render_effects, []);
+      /**
+       * The same as `#render_effects`, but for `$effect` (which runs after)
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _effects, []);
+      /**
+       * Block effects, which may need to re-run on subsequent flushes
+       * in order to update internal sources (e.g. each block items)
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _block_effects, []);
+      /**
+       * A set of branches that still exist, but will be destroyed when this batch
+       * is committed — we skip over these during `process`
+       * @type {Set<Effect>}
+       */
+      __publicField(this, "skipped_effects", /* @__PURE__ */ new Set());
+    }
+    /**
+     * Associate a change to a given source with the current
+     * batch, noting its previous and current values
+     * @param {Source} source
+     * @param {any} value
+     */
+    capture(source2, value) {
+      if (!__privateGet(this, _previous).has(source2)) {
+        __privateGet(this, _previous).set(source2, value);
+      }
+      __privateGet(this, _current).set(source2, source2.v);
+    }
+    activate() {
+      current_batch = this;
+    }
+    deactivate() {
+      current_batch = null;
+      for (const update of effect_pending_updates) {
+        effect_pending_updates.delete(update);
+        update();
+        if (current_batch !== null) {
+          break;
+        }
+      }
+    }
+    neuter() {
+      __privateSet(this, _neutered, true);
+    }
+    flush() {
+      if (queued_root_effects.length > 0) {
+        this.flush_effects();
+      } else {
+        __privateMethod(this, _Batch_instances, commit_fn).call(this);
+      }
+      if (current_batch !== this) {
+        return;
+      }
+      if (__privateGet(this, _pending) === 0) {
+        batches.delete(this);
+      }
+      this.deactivate();
+    }
+    flush_effects() {
+      var was_updating_effect = is_updating_effect;
+      is_flushing = true;
+      try {
+        var flush_count = 0;
+        set_is_updating_effect(true);
+        while (queued_root_effects.length > 0) {
+          if (flush_count++ > 1e3) {
+            var updates, entry;
+            if (DEV) ;
+            infinite_loop_guard();
+          }
+          __privateMethod(this, _Batch_instances, process_fn).call(this, queued_root_effects);
+          old_values.clear();
+        }
+      } finally {
+        is_flushing = false;
+        set_is_updating_effect(was_updating_effect);
+        last_scheduled_effect = null;
+      }
+    }
+    increment() {
+      __privateSet(this, _pending, __privateGet(this, _pending) + 1);
+    }
+    decrement() {
+      __privateSet(this, _pending, __privateGet(this, _pending) - 1);
+      if (__privateGet(this, _pending) === 0) {
+        for (const e of __privateGet(this, _render_effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        for (const e of __privateGet(this, _effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        for (const e of __privateGet(this, _block_effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        __privateSet(this, _render_effects, []);
+        __privateSet(this, _effects, []);
+        this.flush();
+      } else {
+        this.deactivate();
+      }
+    }
+    /** @param {() => void} fn */
+    add_callback(fn) {
+      __privateGet(this, _callbacks).add(fn);
+    }
+    settled() {
+      return (__privateGet(this, _deferred) ?? __privateSet(this, _deferred, deferred())).promise;
+    }
+    static ensure(autoflush = true) {
+      if (current_batch === null) {
+        const batch = current_batch = new _Batch();
+        batches.add(current_batch);
+        if (autoflush) {
+          queueMicrotask(() => {
+            if (current_batch !== batch) {
+              return;
+            }
+            batch.flush();
+          });
+        }
+      }
+      return current_batch;
+    }
+  };
+  _current = new WeakMap();
+  _previous = new WeakMap();
+  _callbacks = new WeakMap();
+  _pending = new WeakMap();
+  _deferred = new WeakMap();
+  _neutered = new WeakMap();
+  _async_effects = new WeakMap();
+  _boundary_async_effects = new WeakMap();
+  _render_effects = new WeakMap();
+  _effects = new WeakMap();
+  _block_effects = new WeakMap();
+  _Batch_instances = new WeakSet();
+  /**
+   *
+   * @param {Effect[]} root_effects
+   */
+  process_fn = function(root_effects) {
+    var _a2;
+    queued_root_effects = [];
+    var current_values = null;
+    if (batches.size > 1) {
+      current_values = /* @__PURE__ */ new Map();
+      batch_deriveds = /* @__PURE__ */ new Map();
+      for (const [source2, current] of __privateGet(this, _current)) {
+        current_values.set(source2, { v: source2.v, wv: source2.wv });
+        source2.v = current;
+      }
+      for (const batch of batches) {
+        if (batch === this) continue;
+        for (const [source2, previous] of __privateGet(batch, _previous)) {
+          if (!current_values.has(source2)) {
+            current_values.set(source2, { v: source2.v, wv: source2.wv });
+            source2.v = previous;
+          }
+        }
+      }
+    }
+    for (const root2 of root_effects) {
+      __privateMethod(this, _Batch_instances, traverse_effect_tree_fn).call(this, root2);
+    }
+    if (__privateGet(this, _async_effects).length === 0 && __privateGet(this, _pending) === 0) {
+      var render_effects = __privateGet(this, _render_effects);
+      var effects = __privateGet(this, _effects);
+      __privateSet(this, _render_effects, []);
+      __privateSet(this, _effects, []);
+      __privateSet(this, _block_effects, []);
+      __privateMethod(this, _Batch_instances, commit_fn).call(this);
+      flush_queued_effects(render_effects);
+      flush_queued_effects(effects);
+      (_a2 = __privateGet(this, _deferred)) == null ? void 0 : _a2.resolve();
+    } else {
+      for (const e of __privateGet(this, _render_effects)) set_signal_status(e, CLEAN);
+      for (const e of __privateGet(this, _effects)) set_signal_status(e, CLEAN);
+      for (const e of __privateGet(this, _block_effects)) set_signal_status(e, CLEAN);
+    }
+    if (current_values) {
+      for (const [source2, { v, wv }] of current_values) {
+        if (source2.wv <= wv) {
+          source2.v = v;
+        }
+      }
+      batch_deriveds = null;
+    }
+    for (const effect2 of __privateGet(this, _async_effects)) {
+      update_effect(effect2);
+    }
+    for (const effect2 of __privateGet(this, _boundary_async_effects)) {
+      update_effect(effect2);
+    }
+    __privateSet(this, _async_effects, []);
+    __privateSet(this, _boundary_async_effects, []);
+  };
+  /**
+   * Traverse the effect tree, executing effects or stashing
+   * them for later execution as appropriate
+   * @param {Effect} root
+   */
+  traverse_effect_tree_fn = function(root2) {
+    var _a2;
+    root2.f ^= CLEAN;
+    var effect2 = root2.first;
+    while (effect2 !== null) {
+      var flags = effect2.f;
+      var is_branch = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) !== 0;
+      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
+      var skip = is_skippable_branch || (flags & INERT) !== 0 || this.skipped_effects.has(effect2);
+      if (!skip && effect2.fn !== null) {
+        if (is_branch) {
+          effect2.f ^= CLEAN;
+        } else if ((flags & EFFECT) !== 0) {
+          __privateGet(this, _effects).push(effect2);
+        } else if (is_dirty(effect2)) {
+          if ((flags & ASYNC) !== 0) {
+            var effects = ((_a2 = effect2.b) == null ? void 0 : _a2.pending) ? __privateGet(this, _boundary_async_effects) : __privateGet(this, _async_effects);
+            effects.push(effect2);
+          } else {
+            if ((effect2.f & BLOCK_EFFECT) !== 0) __privateGet(this, _block_effects).push(effect2);
+            update_effect(effect2);
+          }
+        }
+        var child2 = effect2.first;
+        if (child2 !== null) {
+          effect2 = child2;
+          continue;
+        }
+      }
+      var parent = effect2.parent;
+      effect2 = effect2.next;
+      while (effect2 === null && parent !== null) {
+        effect2 = parent.next;
+        parent = parent.parent;
+      }
+    }
+  };
+  /**
+   * Append and remove branches to/from the DOM
+   */
+  commit_fn = function() {
+    if (!__privateGet(this, _neutered)) {
+      for (const fn of __privateGet(this, _callbacks)) {
+        fn();
+      }
+    }
+    __privateGet(this, _callbacks).clear();
+  };
+  let Batch = _Batch;
+  function flushSync(fn) {
+    var result;
+    const batch = Batch.ensure(false);
+    while (true) {
+      flush_tasks();
+      if (queued_root_effects.length === 0) {
+        if (batch === current_batch) {
+          batch.flush();
+        }
+        last_scheduled_effect = null;
+        return (
+          /** @type {T} */
+          result
+        );
+      }
+      batch.flush_effects();
     }
   }
-  function state_prototype_fixed() {
-    {
-      throw new Error("state_prototype_fixed");
+  function infinite_loop_guard() {
+    try {
+      effect_update_depth_exceeded();
+    } catch (error) {
+      invoke_error_boundary(error, last_scheduled_effect);
     }
   }
-  function state_unsafe_local_read() {
-    {
-      throw new Error("state_unsafe_local_read");
+  function flush_queued_effects(effects) {
+    var length = effects.length;
+    if (length === 0) return;
+    for (var i = 0; i < length; i++) {
+      var effect2 = effects[i];
+      if ((effect2.f & (DESTROYED | INERT)) === 0) {
+        if (is_dirty(effect2)) {
+          var wv = write_version;
+          update_effect(effect2);
+          if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
+            if (effect2.teardown === null && effect2.ac === null) {
+              unlink_effect(effect2);
+            } else {
+              effect2.fn = null;
+            }
+          }
+          if (write_version > wv && (effect2.f & USER_EFFECT) !== 0) {
+            break;
+          }
+        }
+      }
+    }
+    for (; i < length; i += 1) {
+      schedule_effect(effects[i]);
     }
   }
-  function state_unsafe_mutation() {
-    {
-      throw new Error("state_unsafe_mutation");
+  function schedule_effect(signal) {
+    var effect2 = last_scheduled_effect = signal;
+    while (effect2.parent !== null) {
+      effect2 = effect2.parent;
+      var flags = effect2.f;
+      if (is_flushing && effect2 === active_effect && (flags & BLOCK_EFFECT) !== 0) {
+        return;
+      }
+      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+        if ((flags & CLEAN) === 0) return;
+        effect2.f ^= CLEAN;
+      }
     }
+    queued_root_effects.push(effect2);
   }
-  function source(v) {
-    return {
+  const old_values = /* @__PURE__ */ new Map();
+  function source(v, stack) {
+    var signal = {
       f: 0,
       // TODO ideally we could skip this altogether, but it causes type errors
       v,
       reactions: null,
       equals,
-      version: 0
+      rv: 0,
+      wv: 0
     };
-  }
-  function state(v) {
-    return /* @__PURE__ */ push_derived_source(source(v));
+    return signal;
   }
   // @__NO_SIDE_EFFECTS__
-  function mutable_source(initial_value, immutable = false) {
-    var _a;
+  function state(v, stack) {
+    const s = source(v);
+    push_reaction_value(s);
+    return s;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function mutable_source(initial_value, immutable = false, trackable = true) {
+    var _a2;
     const s = source(initial_value);
     if (!immutable) {
       s.equals = safe_equals;
     }
-    if (component_context !== null && component_context.l !== null) {
-      ((_a = component_context.l).s ?? (_a.s = [])).push(s);
+    if (legacy_mode_flag && trackable && component_context !== null && component_context.l !== null) {
+      ((_a2 = component_context.l).s ?? (_a2.s = [])).push(s);
     }
     return s;
   }
-  function mutable_state(v, immutable = false) {
-    return /* @__PURE__ */ push_derived_source(/* @__PURE__ */ mutable_source(v, immutable));
-  }
-  // @__NO_SIDE_EFFECTS__
-  function push_derived_source(source2) {
-    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-      if (derived_sources === null) {
-        set_derived_sources([source2]);
-      } else {
-        derived_sources.push(source2);
-      }
-    }
-    return source2;
-  }
-  function set(source2, value) {
-    if (active_reaction !== null && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT)) !== 0 && // If the source was created locally within the current derived, then
-    // we allow the mutation.
-    (derived_sources === null || !derived_sources.includes(source2))) {
+  function set(source2, value, should_proxy = false) {
+    if (active_reaction !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
+    // to ensure we error if state is set inside an inspect effect
+    (!untracking || (active_reaction.f & INSPECT_EFFECT) !== 0) && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT | ASYNC | INSPECT_EFFECT)) !== 0 && !(current_sources == null ? void 0 : current_sources.includes(source2))) {
       state_unsafe_mutation();
     }
-    return internal_set(source2, value);
+    let new_value = should_proxy ? proxy(value) : value;
+    return internal_set(source2, new_value);
   }
   function internal_set(source2, value) {
     if (!source2.equals(value)) {
+      var old_value = source2.v;
+      if (is_destroying_effect) {
+        old_values.set(source2, value);
+      } else {
+        old_values.set(source2, old_value);
+      }
       source2.v = value;
-      source2.version = increment_version();
+      const batch = Batch.ensure();
+      batch.capture(source2, old_value);
+      if ((source2.f & DERIVED) !== 0) {
+        if ((source2.f & DIRTY) !== 0) {
+          execute_derived(
+            /** @type {Derived} */
+            source2
+          );
+        }
+        set_signal_status(source2, (source2.f & UNOWNED) === 0 ? CLEAN : MAYBE_DIRTY);
+      }
+      source2.wv = increment_write_version();
       mark_reactions(source2, DIRTY);
-      if (is_runes() && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0) {
-        if (new_deps !== null && new_deps.includes(source2)) {
-          set_signal_status(active_effect, DIRTY);
-          schedule_effect(active_effect);
+      if (is_runes() && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
+        if (untracked_writes === null) {
+          set_untracked_writes([source2]);
         } else {
-          if (untracked_writes === null) {
-            set_untracked_writes([source2]);
-          } else {
-            untracked_writes.push(source2);
-          }
+          untracked_writes.push(source2);
         }
       }
     }
     return value;
+  }
+  function increment(source2) {
+    set(source2, source2.v + 1);
   }
   function mark_reactions(signal, status) {
     var reactions = signal.reactions;
@@ -368,24 +1171,7 @@
       }
     }
   }
-  const EACH_ITEM_REACTIVE = 1;
-  const EACH_INDEX_REACTIVE = 1 << 1;
-  const EACH_IS_CONTROLLED = 1 << 2;
-  const EACH_IS_ANIMATED = 1 << 3;
-  const EACH_ITEM_IMMUTABLE = 1 << 4;
-  const PROPS_IS_IMMUTABLE = 1;
-  const PROPS_IS_RUNES = 1 << 1;
-  const PROPS_IS_UPDATED = 1 << 2;
-  const PROPS_IS_BINDABLE = 1 << 3;
-  const PROPS_IS_LAZY_INITIAL = 1 << 4;
-  const TRANSITION_IN = 1;
-  const TRANSITION_OUT = 1 << 1;
-  const TRANSITION_GLOBAL = 1 << 2;
-  const TEMPLATE_FRAGMENT = 1;
-  const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
-  const UNINITIALIZED = Symbol();
-  let hydrating = false;
-  function proxy(value, parent = null, prev2) {
+  function proxy(value) {
     if (typeof value !== "object" || value === null || STATE_SYMBOL in value) {
       return value;
     }
@@ -395,14 +1181,27 @@
     }
     var sources = /* @__PURE__ */ new Map();
     var is_proxied_array = is_array(value);
-    var version = source(0);
+    var version = /* @__PURE__ */ state(0);
+    var parent_version = update_version;
+    var with_parent = (fn) => {
+      if (update_version === parent_version) {
+        return fn();
+      }
+      var reaction = active_reaction;
+      var version2 = update_version;
+      set_active_reaction(null);
+      set_update_version(parent_version);
+      var result = fn();
+      set_active_reaction(reaction);
+      set_update_version(version2);
+      return result;
+    };
     if (is_proxied_array) {
-      sources.set("length", source(
+      sources.set("length", /* @__PURE__ */ state(
         /** @type {any[]} */
         value.length
       ));
     }
-    var metadata;
     return new Proxy(
       /** @type {any} */
       value,
@@ -413,10 +1212,13 @@
           }
           var s = sources.get(prop2);
           if (s === void 0) {
-            s = source(descriptor.value);
-            sources.set(prop2, s);
+            s = with_parent(() => {
+              var s2 = /* @__PURE__ */ state(descriptor.value);
+              sources.set(prop2, s2);
+              return s2;
+            });
           } else {
-            set(s, proxy(descriptor.value, metadata));
+            set(s, descriptor.value, true);
           }
           return true;
         },
@@ -424,33 +1226,29 @@
           var s = sources.get(prop2);
           if (s === void 0) {
             if (prop2 in target) {
-              sources.set(prop2, source(UNINITIALIZED));
+              const s2 = with_parent(() => /* @__PURE__ */ state(UNINITIALIZED));
+              sources.set(prop2, s2);
+              increment(version);
             }
           } else {
-            if (is_proxied_array && typeof prop2 === "string") {
-              var ls = (
-                /** @type {Source<number>} */
-                sources.get("length")
-              );
-              var n = Number(prop2);
-              if (Number.isInteger(n) && n < ls.v) {
-                set(ls, n);
-              }
-            }
             set(s, UNINITIALIZED);
-            update_version(version);
+            increment(version);
           }
           return true;
         },
         get(target, prop2, receiver) {
-          var _a;
+          var _a2;
           if (prop2 === STATE_SYMBOL) {
             return value;
           }
           var s = sources.get(prop2);
           var exists = prop2 in target;
-          if (s === void 0 && (!exists || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable))) {
-            s = source(proxy(exists ? target[prop2] : UNINITIALIZED, metadata));
+          if (s === void 0 && (!exists || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable))) {
+            s = with_parent(() => {
+              var p = proxy(exists ? target[prop2] : UNINITIALIZED);
+              var s2 = /* @__PURE__ */ state(p);
+              return s2;
+            });
             sources.set(prop2, s);
           }
           if (s !== void 0) {
@@ -479,15 +1277,19 @@
           return descriptor;
         },
         has(target, prop2) {
-          var _a;
+          var _a2;
           if (prop2 === STATE_SYMBOL) {
             return true;
           }
           var s = sources.get(prop2);
           var has = s !== void 0 && s.v !== UNINITIALIZED || Reflect.has(target, prop2);
-          if (s !== void 0 || active_effect !== null && (!has || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable))) {
+          if (s !== void 0 || active_effect !== null && (!has || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable))) {
             if (s === void 0) {
-              s = source(has ? proxy(target[prop2], metadata) : UNINITIALIZED);
+              s = with_parent(() => {
+                var p = has ? proxy(target[prop2]) : UNINITIALIZED;
+                var s2 = /* @__PURE__ */ state(p);
+                return s2;
+              });
               sources.set(prop2, s);
             }
             var value2 = get(s);
@@ -498,7 +1300,7 @@
           return has;
         },
         set(target, prop2, value2, receiver) {
-          var _a;
+          var _a2;
           var s = sources.get(prop2);
           var has = prop2 in target;
           if (is_proxied_array && prop2 === "length") {
@@ -508,20 +1310,21 @@
               if (other_s !== void 0) {
                 set(other_s, UNINITIALIZED);
               } else if (i in target) {
-                other_s = source(UNINITIALIZED);
+                other_s = with_parent(() => /* @__PURE__ */ state(UNINITIALIZED));
                 sources.set(i + "", other_s);
               }
             }
           }
           if (s === void 0) {
-            if (!has || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable)) {
-              s = source(void 0);
-              set(s, proxy(value2, metadata));
+            if (!has || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable)) {
+              s = with_parent(() => /* @__PURE__ */ state(void 0));
+              set(s, proxy(value2));
               sources.set(prop2, s);
             }
           } else {
             has = s.v !== UNINITIALIZED;
-            set(s, proxy(value2, metadata));
+            var p = with_parent(() => proxy(value2));
+            set(s, p);
           }
           var descriptor = Reflect.getOwnPropertyDescriptor(target, prop2);
           if (descriptor == null ? void 0 : descriptor.set) {
@@ -538,7 +1341,7 @@
                 set(ls, n + 1);
               }
             }
-            update_version(version);
+            increment(version);
           }
           return true;
         },
@@ -561,10 +1364,8 @@
       }
     );
   }
-  function update_version(signal, d = 1) {
-    set(signal, signal.v + d);
-  }
   var $window;
+  var is_firefox;
   var first_child_getter;
   var next_sibling_getter;
   function init_operations() {
@@ -572,16 +1373,22 @@
       return;
     }
     $window = window;
+    is_firefox = /Firefox/.test(navigator.userAgent);
     var element_prototype = Element.prototype;
     var node_prototype = Node.prototype;
+    var text_prototype = Text.prototype;
     first_child_getter = get_descriptor(node_prototype, "firstChild").get;
     next_sibling_getter = get_descriptor(node_prototype, "nextSibling").get;
-    element_prototype.__click = void 0;
-    element_prototype.__className = "";
-    element_prototype.__attributes = null;
-    element_prototype.__styles = null;
-    element_prototype.__e = void 0;
-    Text.prototype.__t = void 0;
+    if (is_extensible(element_prototype)) {
+      element_prototype.__click = void 0;
+      element_prototype.__className = void 0;
+      element_prototype.__attributes = null;
+      element_prototype.__style = void 0;
+      element_prototype.__e = void 0;
+    }
+    if (is_extensible(text_prototype)) {
+      text_prototype.__t = void 0;
+    }
   }
   function create_text(value = "") {
     return document.createTextNode(value);
@@ -625,98 +1432,11 @@
   function clear_text_content(node) {
     node.textContent = "";
   }
-  // @__NO_SIDE_EFFECTS__
-  function derived(fn) {
-    var flags = DERIVED | DIRTY;
-    if (active_effect === null) {
-      flags |= UNOWNED;
-    } else {
-      active_effect.f |= EFFECT_HAS_DERIVED;
-    }
-    const signal = {
-      children: null,
-      ctx: component_context,
-      deps: null,
-      equals,
-      f: flags,
-      fn,
-      reactions: null,
-      v: (
-        /** @type {V} */
-        null
-      ),
-      version: 0,
-      parent: active_effect
-    };
-    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-      var derived2 = (
-        /** @type {Derived} */
-        active_reaction
-      );
-      (derived2.children ?? (derived2.children = [])).push(signal);
-    }
-    return signal;
-  }
-  // @__NO_SIDE_EFFECTS__
-  function derived_safe_equal(fn) {
-    const signal = /* @__PURE__ */ derived(fn);
-    signal.equals = safe_equals;
-    return signal;
-  }
-  function destroy_derived_children(derived2) {
-    var children = derived2.children;
-    if (children !== null) {
-      derived2.children = null;
-      for (var i = 0; i < children.length; i += 1) {
-        var child2 = children[i];
-        if ((child2.f & DERIVED) !== 0) {
-          destroy_derived(
-            /** @type {Derived} */
-            child2
-          );
-        } else {
-          destroy_effect(
-            /** @type {Effect} */
-            child2
-          );
-        }
-      }
-    }
-  }
-  function execute_derived(derived2) {
-    var value;
-    var prev_active_effect = active_effect;
-    set_active_effect(derived2.parent);
-    {
-      try {
-        destroy_derived_children(derived2);
-        value = update_reaction(derived2);
-      } finally {
-        set_active_effect(prev_active_effect);
-      }
-    }
-    return value;
-  }
-  function update_derived(derived2) {
-    var value = execute_derived(derived2);
-    var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
-    set_signal_status(derived2, status);
-    if (!derived2.equals(value)) {
-      derived2.v = value;
-      derived2.version = increment_version();
-    }
-  }
-  function destroy_derived(signal) {
-    destroy_derived_children(signal);
-    remove_reactions(signal, 0);
-    set_signal_status(signal, DESTROYED);
-    signal.v = signal.children = signal.deps = signal.ctx = signal.reactions = null;
-  }
   function validate_effect(rune) {
     if (active_effect === null && active_reaction === null) {
       effect_orphan();
     }
-    if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0) {
+    if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0 && active_effect === null) {
       effect_in_unowned_derived();
     }
     if (is_destroying_effect) {
@@ -734,12 +1454,13 @@
     }
   }
   function create_effect(type, fn, sync, push2 = true) {
-    var is_root = (type & ROOT_EFFECT) !== 0;
-    var parent_effect = active_effect;
+    var parent = active_effect;
+    if (parent !== null && (parent.f & INERT) !== 0) {
+      type |= INERT;
+    }
     var effect2 = {
       ctx: component_context,
       deps: null,
-      deriveds: null,
       nodes_start: null,
       nodes_end: null,
       f: type | DIRTY,
@@ -747,38 +1468,36 @@
       fn,
       last: null,
       next: null,
-      parent: is_root ? null : parent_effect,
+      parent,
+      b: parent && parent.b,
       prev: null,
       teardown: null,
       transitions: null,
-      version: 0
+      wv: 0,
+      ac: null
     };
     if (sync) {
-      var previously_flushing_effect = is_flushing_effect;
       try {
-        set_is_flushing_effect(true);
         update_effect(effect2);
         effect2.f |= EFFECT_RAN;
       } catch (e) {
         destroy_effect(effect2);
         throw e;
-      } finally {
-        set_is_flushing_effect(previously_flushing_effect);
       }
     } else if (fn !== null) {
       schedule_effect(effect2);
     }
-    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & EFFECT_HAS_DERIVED) === 0;
-    if (!inert && !is_root && push2) {
-      if (parent_effect !== null) {
-        push_effect(effect2, parent_effect);
+    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & EFFECT_PRESERVED) === 0;
+    if (!inert && push2) {
+      if (parent !== null) {
+        push_effect(effect2, parent);
       }
       if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
         var derived2 = (
           /** @type {Derived} */
           active_reaction
         );
-        (derived2.children ?? (derived2.children = [])).push(effect2);
+        (derived2.effects ?? (derived2.effects = [])).push(effect2);
       }
     }
     return effect2;
@@ -791,46 +1510,65 @@
   }
   function user_effect(fn) {
     validate_effect();
-    var defer = active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && component_context !== null && !component_context.m;
+    var flags = (
+      /** @type {Effect} */
+      active_effect.f
+    );
+    var defer = !active_reaction && (flags & BRANCH_EFFECT) !== 0 && (flags & EFFECT_RAN) === 0;
     if (defer) {
       var context = (
         /** @type {ComponentContext} */
         component_context
       );
-      (context.e ?? (context.e = [])).push({
-        fn,
-        effect: active_effect,
-        reaction: active_reaction
-      });
+      (context.e ?? (context.e = [])).push(fn);
     } else {
-      var signal = effect(fn);
-      return signal;
+      return create_user_effect(fn);
     }
+  }
+  function create_user_effect(fn) {
+    return create_effect(EFFECT | USER_EFFECT, fn, false);
   }
   function user_pre_effect(fn) {
     validate_effect();
-    return render_effect(fn);
+    return create_effect(RENDER_EFFECT | USER_EFFECT, fn, true);
   }
-  function effect_root(fn) {
+  function component_root(fn) {
+    Batch.ensure();
     const effect2 = create_effect(ROOT_EFFECT, fn, true);
-    return () => {
-      destroy_effect(effect2);
+    return (options = {}) => {
+      return new Promise((fulfil) => {
+        if (options.outro) {
+          pause_effect(effect2, () => {
+            destroy_effect(effect2);
+            fulfil(void 0);
+          });
+        } else {
+          destroy_effect(effect2);
+          fulfil(void 0);
+        }
+      });
     };
   }
   function effect(fn) {
     return create_effect(EFFECT, fn, false);
   }
-  function render_effect(fn) {
-    return create_effect(RENDER_EFFECT, fn, true);
+  function async_effect(fn) {
+    return create_effect(ASYNC | EFFECT_PRESERVED, fn, true);
   }
-  function template_effect(fn) {
-    return block(fn);
+  function render_effect(fn, flags = 0) {
+    return create_effect(RENDER_EFFECT | flags, fn, true);
+  }
+  function template_effect(fn, sync = [], async = []) {
+    flatten(sync, async, (values) => {
+      create_effect(RENDER_EFFECT, () => fn(...values.map(get)), true);
+    });
   }
   function block(fn, flags = 0) {
-    return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
+    var effect2 = create_effect(BLOCK_EFFECT | flags, fn, true);
+    return effect2;
   }
   function branch(fn, push2 = true) {
-    return create_effect(RENDER_EFFECT | BRANCH_EFFECT, fn, true, push2);
+    return create_effect(BRANCH_EFFECT, fn, true, push2);
   }
   function execute_effect_teardown(effect2) {
     var teardown2 = effect2.teardown;
@@ -847,21 +1585,18 @@
       }
     }
   }
-  function destroy_effect_deriveds(signal) {
-    var deriveds = signal.deriveds;
-    if (deriveds !== null) {
-      signal.deriveds = null;
-      for (var i = 0; i < deriveds.length; i += 1) {
-        destroy_derived(deriveds[i]);
-      }
-    }
-  }
   function destroy_effect_children(signal, remove_dom = false) {
+    var _a2;
     var effect2 = signal.first;
     signal.first = signal.last = null;
     while (effect2 !== null) {
+      (_a2 = effect2.ac) == null ? void 0 : _a2.abort(STALE_REACTION);
       var next2 = effect2.next;
-      destroy_effect(effect2, remove_dom);
+      if ((effect2.f & ROOT_EFFECT) !== 0) {
+        effect2.parent = null;
+      } else {
+        destroy_effect(effect2, remove_dom);
+      }
       effect2 = next2;
     }
   }
@@ -877,20 +1612,14 @@
   }
   function destroy_effect(effect2, remove_dom = true) {
     var removed = false;
-    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null) {
-      var node = effect2.nodes_start;
-      var end = effect2.nodes_end;
-      while (node !== null) {
-        var next2 = node === end ? null : (
-          /** @type {TemplateNode} */
-          /* @__PURE__ */ get_next_sibling(node)
-        );
-        node.remove();
-        node = next2;
-      }
+    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null && effect2.nodes_end !== null) {
+      remove_effect_dom(
+        effect2.nodes_start,
+        /** @type {TemplateNode} */
+        effect2.nodes_end
+      );
       removed = true;
     }
-    destroy_effect_deriveds(effect2);
     destroy_effect_children(effect2, remove_dom && !removed);
     remove_reactions(effect2, 0);
     set_signal_status(effect2, DESTROYED);
@@ -905,7 +1634,17 @@
     if (parent !== null && parent.first !== null) {
       unlink_effect(effect2);
     }
-    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.parent = effect2.fn = effect2.nodes_start = effect2.nodes_end = null;
+    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.fn = effect2.nodes_start = effect2.nodes_end = effect2.ac = null;
+  }
+  function remove_effect_dom(node, end) {
+    while (node !== null) {
+      var next2 = node === end ? null : (
+        /** @type {TemplateNode} */
+        /* @__PURE__ */ get_next_sibling(node)
+      );
+      node.remove();
+      node = next2;
+    }
   }
   function unlink_effect(effect2) {
     var parent = effect2.parent;
@@ -961,8 +1700,9 @@
   function resume_children(effect2, local) {
     if ((effect2.f & INERT) === 0) return;
     effect2.f ^= INERT;
-    if (check_dirtiness(effect2)) {
-      update_effect(effect2);
+    if ((effect2.f & CLEAN) === 0) {
+      set_signal_status(effect2, DIRTY);
+      schedule_effect(effect2);
     }
     var child2 = effect2.first;
     while (child2 !== null) {
@@ -979,46 +1719,16 @@
       }
     }
   }
-  let is_micro_task_queued$1 = false;
-  let current_queued_micro_tasks = [];
-  function process_micro_tasks() {
-    is_micro_task_queued$1 = false;
-    const tasks = current_queued_micro_tasks.slice();
-    current_queued_micro_tasks = [];
-    run_all(tasks);
+  let is_updating_effect = false;
+  function set_is_updating_effect(value) {
+    is_updating_effect = value;
   }
-  function queue_micro_task(fn) {
-    if (!is_micro_task_queued$1) {
-      is_micro_task_queued$1 = true;
-      queueMicrotask(process_micro_tasks);
-    }
-    current_queued_micro_tasks.push(fn);
-  }
-  function flush_tasks() {
-    if (is_micro_task_queued$1) {
-      process_micro_tasks();
-    }
-  }
-  function lifecycle_outside_component(name) {
-    {
-      throw new Error("lifecycle_outside_component");
-    }
-  }
-  const FLUSH_MICROTASK = 0;
-  const FLUSH_SYNC = 1;
-  let scheduler_mode = FLUSH_MICROTASK;
-  let is_micro_task_queued = false;
-  let is_flushing_effect = false;
   let is_destroying_effect = false;
-  function set_is_flushing_effect(value) {
-    is_flushing_effect = value;
-  }
   function set_is_destroying_effect(value) {
     is_destroying_effect = value;
   }
-  let queued_root_effects = [];
-  let flush_count = 0;
   let active_reaction = null;
+  let untracking = false;
   function set_active_reaction(reaction) {
     active_reaction = reaction;
   }
@@ -1026,9 +1736,15 @@
   function set_active_effect(effect2) {
     active_effect = effect2;
   }
-  let derived_sources = null;
-  function set_derived_sources(sources) {
-    derived_sources = sources;
+  let current_sources = null;
+  function push_reaction_value(value) {
+    if (active_reaction !== null && !async_mode_flag) {
+      if (current_sources === null) {
+        current_sources = [value];
+      } else {
+        current_sources.push(value);
+      }
+    }
   }
   let new_deps = null;
   let skipped_deps = 0;
@@ -1036,20 +1752,18 @@
   function set_untracked_writes(value) {
     untracked_writes = value;
   }
-  let current_version = 0;
+  let write_version = 1;
+  let read_version = 0;
+  let update_version = read_version;
+  function set_update_version(value) {
+    update_version = value;
+  }
   let skip_reaction = false;
-  let component_context = null;
-  function set_component_context(context) {
-    component_context = context;
+  function increment_write_version() {
+    return ++write_version;
   }
-  function increment_version() {
-    return ++current_version;
-  }
-  function is_runes() {
-    return component_context !== null && component_context.l === null;
-  }
-  function check_dirtiness(reaction) {
-    var _a, _b;
+  function is_dirty(reaction) {
+    var _a2;
     var flags = reaction.f;
     if ((flags & DIRTY) !== 0) {
       return true;
@@ -1059,15 +1773,32 @@
       var is_unowned = (flags & UNOWNED) !== 0;
       if (dependencies !== null) {
         var i;
-        if ((flags & DISCONNECTED) !== 0) {
-          for (i = 0; i < dependencies.length; i++) {
-            ((_a = dependencies[i]).reactions ?? (_a.reactions = [])).push(reaction);
+        var dependency;
+        var is_disconnected = (flags & DISCONNECTED) !== 0;
+        var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
+        var length = dependencies.length;
+        if ((is_disconnected || is_unowned_connected) && (active_effect === null || (active_effect.f & DESTROYED) === 0)) {
+          var derived2 = (
+            /** @type {Derived} */
+            reaction
+          );
+          var parent = derived2.parent;
+          for (i = 0; i < length; i++) {
+            dependency = dependencies[i];
+            if (is_disconnected || !((_a2 = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _a2.includes(derived2))) {
+              (dependency.reactions ?? (dependency.reactions = [])).push(derived2);
+            }
           }
-          reaction.f ^= DISCONNECTED;
+          if (is_disconnected) {
+            derived2.f ^= DISCONNECTED;
+          }
+          if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
+            derived2.f ^= UNOWNED;
+          }
         }
-        for (i = 0; i < dependencies.length; i++) {
-          var dependency = dependencies[i];
-          if (check_dirtiness(
+        for (i = 0; i < length; i++) {
+          dependency = dependencies[i];
+          if (is_dirty(
             /** @type {Derived} */
             dependency
           )) {
@@ -1076,44 +1807,73 @@
               dependency
             );
           }
-          if (is_unowned && active_effect !== null && !skip_reaction && !((_b = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _b.includes(reaction))) {
-            (dependency.reactions ?? (dependency.reactions = [])).push(reaction);
-          }
-          if (dependency.version > reaction.version) {
+          if (dependency.wv > reaction.wv) {
             return true;
           }
         }
       }
-      if (!is_unowned) {
+      if (!is_unowned || active_effect !== null && !skip_reaction) {
         set_signal_status(reaction, CLEAN);
       }
     }
     return false;
   }
-  function handle_error(error, effect2, component_context2) {
-    {
-      throw error;
+  function schedule_possible_effect_self_invalidation(signal, effect2, root2 = true) {
+    var reactions = signal.reactions;
+    if (reactions === null) return;
+    if (current_sources == null ? void 0 : current_sources.includes(signal)) {
+      return;
+    }
+    for (var i = 0; i < reactions.length; i++) {
+      var reaction = reactions[i];
+      if ((reaction.f & DERIVED) !== 0) {
+        schedule_possible_effect_self_invalidation(
+          /** @type {Derived} */
+          reaction,
+          effect2,
+          false
+        );
+      } else if (effect2 === reaction) {
+        if (root2) {
+          set_signal_status(reaction, DIRTY);
+        } else if ((reaction.f & CLEAN) !== 0) {
+          set_signal_status(reaction, MAYBE_DIRTY);
+        }
+        schedule_effect(
+          /** @type {Effect} */
+          reaction
+        );
+      }
     }
   }
   function update_reaction(reaction) {
-    var _a;
+    var _a2;
     var previous_deps = new_deps;
     var previous_skipped_deps = skipped_deps;
     var previous_untracked_writes = untracked_writes;
     var previous_reaction = active_reaction;
     var previous_skip_reaction = skip_reaction;
-    var prev_derived_sources = derived_sources;
+    var previous_sources = current_sources;
     var previous_component_context = component_context;
+    var previous_untracking = untracking;
+    var previous_update_version = update_version;
     var flags = reaction.f;
     new_deps = /** @type {null | Value[]} */
     null;
     skipped_deps = 0;
     untracked_writes = null;
+    skip_reaction = (flags & UNOWNED) !== 0 && (untracking || !is_updating_effect || active_reaction === null);
     active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
-    skip_reaction = !is_flushing_effect && (flags & UNOWNED) !== 0;
-    derived_sources = null;
-    component_context = reaction.ctx;
+    current_sources = null;
+    set_component_context(reaction.ctx);
+    untracking = false;
+    update_version = ++read_version;
+    if (reaction.ac !== null) {
+      reaction.ac.abort(STALE_REACTION);
+      reaction.ac = null;
+    }
     try {
+      reaction.f |= REACTION_IS_UPDATING;
       var result = (
         /** @type {Function} */
         (0, reaction.fn)()
@@ -1130,30 +1890,61 @@
         } else {
           reaction.deps = deps = new_deps;
         }
-        if (!skip_reaction) {
+        if (!skip_reaction || // Deriveds that already have reactions can cleanup, so we still add them as reactions
+        (flags & DERIVED) !== 0 && /** @type {import('#client').Derived} */
+        reaction.reactions !== null) {
           for (i = skipped_deps; i < deps.length; i++) {
-            ((_a = deps[i]).reactions ?? (_a.reactions = [])).push(reaction);
+            ((_a2 = deps[i]).reactions ?? (_a2.reactions = [])).push(reaction);
           }
         }
       } else if (deps !== null && skipped_deps < deps.length) {
         remove_reactions(reaction, skipped_deps);
         deps.length = skipped_deps;
       }
+      if (is_runes() && untracked_writes !== null && !untracking && deps !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
+        for (i = 0; i < /** @type {Source[]} */
+        untracked_writes.length; i++) {
+          schedule_possible_effect_self_invalidation(
+            untracked_writes[i],
+            /** @type {Effect} */
+            reaction
+          );
+        }
+      }
+      if (previous_reaction !== null && previous_reaction !== reaction) {
+        read_version++;
+        if (untracked_writes !== null) {
+          if (previous_untracked_writes === null) {
+            previous_untracked_writes = untracked_writes;
+          } else {
+            previous_untracked_writes.push(.../** @type {Source[]} */
+            untracked_writes);
+          }
+        }
+      }
+      if ((reaction.f & ERROR_VALUE) !== 0) {
+        reaction.f ^= ERROR_VALUE;
+      }
       return result;
+    } catch (error) {
+      return handle_error(error);
     } finally {
+      reaction.f ^= REACTION_IS_UPDATING;
       new_deps = previous_deps;
       skipped_deps = previous_skipped_deps;
       untracked_writes = previous_untracked_writes;
       active_reaction = previous_reaction;
       skip_reaction = previous_skip_reaction;
-      derived_sources = prev_derived_sources;
-      component_context = previous_component_context;
+      current_sources = previous_sources;
+      set_component_context(previous_component_context);
+      untracking = previous_untracking;
+      update_version = previous_update_version;
     }
   }
   function remove_reaction(signal, dependency) {
     let reactions = dependency.reactions;
     if (reactions !== null) {
-      var index2 = reactions.indexOf(signal);
+      var index2 = index_of.call(reactions, signal);
       if (index2 !== -1) {
         var new_length = reactions.length - 1;
         if (new_length === 0) {
@@ -1172,6 +1963,10 @@
       if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
         dependency.f ^= DISCONNECTED;
       }
+      destroy_derived_effects(
+        /** @type {Derived} **/
+        dependency
+      );
       remove_reactions(
         /** @type {Derived} **/
         dependency,
@@ -1193,9 +1988,10 @@
     }
     set_signal_status(effect2, CLEAN);
     var previous_effect = active_effect;
+    var was_updating_effect = is_updating_effect;
     active_effect = effect2;
+    is_updating_effect = true;
     try {
-      destroy_effect_deriveds(effect2);
       if ((flags & BLOCK_EFFECT) !== 0) {
         destroy_block_effect_children(effect2);
       } else {
@@ -1204,274 +2000,111 @@
       execute_effect_teardown(effect2);
       var teardown2 = update_reaction(effect2);
       effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
-      effect2.version = current_version;
-      if (DEV) ;
-    } catch (error) {
-      handle_error(
-        /** @type {Error} */
-        error
-      );
+      effect2.wv = write_version;
+      var dep;
+      if (DEV && tracing_mode_flag && (effect2.f & DIRTY) !== 0 && effect2.deps !== null) ;
     } finally {
+      is_updating_effect = was_updating_effect;
       active_effect = previous_effect;
     }
   }
-  function infinite_loop_guard() {
-    if (flush_count > 1e3) {
-      flush_count = 0;
-      {
-        effect_update_depth_exceeded();
-      }
-    }
-    flush_count++;
-  }
-  function flush_queued_root_effects(root_effects) {
-    var length = root_effects.length;
-    if (length === 0) {
-      return;
-    }
-    infinite_loop_guard();
-    var previously_flushing_effect = is_flushing_effect;
-    is_flushing_effect = true;
-    try {
-      for (var i = 0; i < length; i++) {
-        var effect2 = root_effects[i];
-        if ((effect2.f & CLEAN) === 0) {
-          effect2.f ^= CLEAN;
-        }
-        var collected_effects = [];
-        process_effects(effect2, collected_effects);
-        flush_queued_effects(collected_effects);
-      }
-    } finally {
-      is_flushing_effect = previously_flushing_effect;
-    }
-  }
-  function flush_queued_effects(effects) {
-    var length = effects.length;
-    if (length === 0) return;
-    for (var i = 0; i < length; i++) {
-      var effect2 = effects[i];
-      if ((effect2.f & (DESTROYED | INERT)) === 0 && check_dirtiness(effect2)) {
-        update_effect(effect2);
-        if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
-          if (effect2.teardown === null) {
-            unlink_effect(effect2);
-          } else {
-            effect2.fn = null;
-          }
-        }
-      }
-    }
-  }
-  function process_deferred() {
-    is_micro_task_queued = false;
-    if (flush_count > 1001) {
-      return;
-    }
-    const previous_queued_root_effects = queued_root_effects;
-    queued_root_effects = [];
-    flush_queued_root_effects(previous_queued_root_effects);
-    if (!is_micro_task_queued) {
-      flush_count = 0;
-    }
-  }
-  function schedule_effect(signal) {
-    if (scheduler_mode === FLUSH_MICROTASK) {
-      if (!is_micro_task_queued) {
-        is_micro_task_queued = true;
-        queueMicrotask(process_deferred);
-      }
-    }
-    var effect2 = signal;
-    while (effect2.parent !== null) {
-      effect2 = effect2.parent;
-      var flags = effect2.f;
-      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
-        if ((flags & CLEAN) === 0) return;
-        effect2.f ^= CLEAN;
-      }
-    }
-    queued_root_effects.push(effect2);
-  }
-  function process_effects(effect2, collected_effects) {
-    var current_effect = effect2.first;
-    var effects = [];
-    main_loop: while (current_effect !== null) {
-      var flags = current_effect.f;
-      var is_branch = (flags & BRANCH_EFFECT) !== 0;
-      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
-      if (!is_skippable_branch && (flags & INERT) === 0) {
-        if ((flags & RENDER_EFFECT) !== 0) {
-          if (is_branch) {
-            current_effect.f ^= CLEAN;
-          } else if (check_dirtiness(current_effect)) {
-            update_effect(current_effect);
-          }
-          var child2 = current_effect.first;
-          if (child2 !== null) {
-            current_effect = child2;
-            continue;
-          }
-        } else if ((flags & EFFECT) !== 0) {
-          effects.push(current_effect);
-        }
-      }
-      var sibling2 = current_effect.next;
-      if (sibling2 === null) {
-        let parent = current_effect.parent;
-        while (parent !== null) {
-          if (effect2 === parent) {
-            break main_loop;
-          }
-          var parent_sibling = parent.next;
-          if (parent_sibling !== null) {
-            current_effect = parent_sibling;
-            continue main_loop;
-          }
-          parent = parent.parent;
-        }
-      }
-      current_effect = sibling2;
-    }
-    for (var i = 0; i < effects.length; i++) {
-      child2 = effects[i];
-      collected_effects.push(child2);
-      process_effects(child2, collected_effects);
-    }
-  }
-  function flush_sync(fn) {
-    var previous_scheduler_mode = scheduler_mode;
-    var previous_queued_root_effects = queued_root_effects;
-    try {
-      infinite_loop_guard();
-      const root_effects = [];
-      scheduler_mode = FLUSH_SYNC;
-      queued_root_effects = root_effects;
-      is_micro_task_queued = false;
-      flush_queued_root_effects(previous_queued_root_effects);
-      var result = fn == null ? void 0 : fn();
-      flush_tasks();
-      if (queued_root_effects.length > 0 || root_effects.length > 0) {
-        flush_sync();
-      }
-      flush_count = 0;
-      if (DEV) ;
-      return result;
-    } finally {
-      scheduler_mode = previous_scheduler_mode;
-      queued_root_effects = previous_queued_root_effects;
-    }
-  }
   function get(signal) {
-    var _a;
     var flags = signal.f;
     var is_derived = (flags & DERIVED) !== 0;
-    if (is_derived && (flags & DESTROYED) !== 0) {
-      var value = execute_derived(
-        /** @type {Derived} */
-        signal
-      );
-      destroy_derived(
-        /** @type {Derived} */
-        signal
-      );
-      return value;
-    }
-    if (active_reaction !== null) {
-      if (derived_sources !== null && derived_sources.includes(signal)) {
-        state_unsafe_local_read();
-      }
-      var deps = active_reaction.deps;
-      if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
-        skipped_deps++;
-      } else if (new_deps === null) {
-        new_deps = [signal];
-      } else {
-        new_deps.push(signal);
-      }
-      if (untracked_writes !== null && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0 && untracked_writes.includes(signal)) {
-        set_signal_status(active_effect, DIRTY);
-        schedule_effect(active_effect);
+    if (active_reaction !== null && !untracking) {
+      var destroyed = active_effect !== null && (active_effect.f & DESTROYED) !== 0;
+      if (!destroyed && !(current_sources == null ? void 0 : current_sources.includes(signal))) {
+        var deps = active_reaction.deps;
+        if ((active_reaction.f & REACTION_IS_UPDATING) !== 0) {
+          if (signal.rv < read_version) {
+            signal.rv = read_version;
+            if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
+              skipped_deps++;
+            } else if (new_deps === null) {
+              new_deps = [signal];
+            } else if (!skip_reaction || !new_deps.includes(signal)) {
+              new_deps.push(signal);
+            }
+          }
+        } else {
+          (active_reaction.deps ?? (active_reaction.deps = [])).push(signal);
+          var reactions = signal.reactions;
+          if (reactions === null) {
+            signal.reactions = [active_reaction];
+          } else if (!reactions.includes(active_reaction)) {
+            reactions.push(active_reaction);
+          }
+        }
       }
     } else if (is_derived && /** @type {Derived} */
-    signal.deps === null) {
+    signal.deps === null && /** @type {Derived} */
+    signal.effects === null) {
       var derived2 = (
         /** @type {Derived} */
         signal
       );
       var parent = derived2.parent;
-      if (parent !== null && !((_a = parent.deriveds) == null ? void 0 : _a.includes(derived2))) {
-        (parent.deriveds ?? (parent.deriveds = [])).push(derived2);
+      if (parent !== null && (parent.f & UNOWNED) === 0) {
+        derived2.f ^= UNOWNED;
       }
     }
-    if (is_derived) {
+    if (is_destroying_effect) {
+      if (old_values.has(signal)) {
+        return old_values.get(signal);
+      }
+      if (is_derived) {
+        derived2 = /** @type {Derived} */
+        signal;
+        var value = derived2.v;
+        if ((derived2.f & CLEAN) !== 0 || depends_on_old_values(derived2)) {
+          value = execute_derived(derived2);
+        }
+        old_values.set(derived2, value);
+        return value;
+      }
+    } else if (is_derived) {
       derived2 = /** @type {Derived} */
       signal;
-      if (check_dirtiness(derived2)) {
+      if (batch_deriveds == null ? void 0 : batch_deriveds.has(derived2)) {
+        return batch_deriveds.get(derived2);
+      }
+      if (is_dirty(derived2)) {
         update_derived(derived2);
       }
     }
+    if ((signal.f & ERROR_VALUE) !== 0) {
+      throw signal.v;
+    }
     return signal.v;
   }
+  function depends_on_old_values(derived2) {
+    if (derived2.v === UNINITIALIZED) return true;
+    if (derived2.deps === null) return false;
+    for (const dep of derived2.deps) {
+      if (old_values.has(dep)) {
+        return true;
+      }
+      if ((dep.f & DERIVED) !== 0 && depends_on_old_values(
+        /** @type {Derived} */
+        dep
+      )) {
+        return true;
+      }
+    }
+    return false;
+  }
   function untrack(fn) {
-    const previous_reaction = active_reaction;
+    var previous_untracking = untracking;
     try {
-      active_reaction = null;
+      untracking = true;
       return fn();
     } finally {
-      active_reaction = previous_reaction;
+      untracking = previous_untracking;
     }
   }
   const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
   function set_signal_status(signal, status) {
     signal.f = signal.f & STATUS_MASK | status;
-  }
-  function push(props, runes = false, fn) {
-    component_context = {
-      p: component_context,
-      c: null,
-      e: null,
-      m: false,
-      s: props,
-      x: null,
-      l: null
-    };
-    if (!runes) {
-      component_context.l = {
-        s: null,
-        u: null,
-        r1: [],
-        r2: source(false)
-      };
-    }
-  }
-  function pop(component) {
-    const context_stack_item = component_context;
-    if (context_stack_item !== null) {
-      const component_effects = context_stack_item.e;
-      if (component_effects !== null) {
-        var previous_effect = active_effect;
-        var previous_reaction = active_reaction;
-        context_stack_item.e = null;
-        try {
-          for (var i = 0; i < component_effects.length; i++) {
-            var component_effect = component_effects[i];
-            set_active_effect(component_effect.effect);
-            set_active_reaction(component_effect.reaction);
-            effect(component_effect.fn);
-          }
-        } finally {
-          set_active_effect(previous_effect);
-          set_active_reaction(previous_reaction);
-        }
-      }
-      component_context = context_stack_item.p;
-      context_stack_item.m = true;
-    }
-    return (
-      /** @type {T} */
-      {}
-    );
   }
   function deep_read_state(value) {
     if (typeof value !== "object" || !value || value instanceof EventTarget) {
@@ -1516,24 +2149,71 @@
       }
     }
   }
+  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
+  function is_passive_event(name) {
+    return PASSIVE_EVENTS.includes(name);
+  }
+  let listening_to_form_reset = false;
+  function add_form_reset_listener() {
+    if (!listening_to_form_reset) {
+      listening_to_form_reset = true;
+      document.addEventListener(
+        "reset",
+        (evt) => {
+          Promise.resolve().then(() => {
+            var _a2;
+            if (!evt.defaultPrevented) {
+              for (
+                const e of
+                /**@type {HTMLFormElement} */
+                evt.target.elements
+              ) {
+                (_a2 = e.__on_r) == null ? void 0 : _a2.call(e);
+              }
+            }
+          });
+        },
+        // In the capture phase to guarantee we get noticed of it (no possiblity of stopPropagation)
+        { capture: true }
+      );
+    }
+  }
+  function without_reactive_context(fn) {
+    var previous_reaction = active_reaction;
+    var previous_effect = active_effect;
+    set_active_reaction(null);
+    set_active_effect(null);
+    try {
+      return fn();
+    } finally {
+      set_active_reaction(previous_reaction);
+      set_active_effect(previous_effect);
+    }
+  }
+  function listen_to_event_and_reset_event(element, event2, handler, on_reset = handler) {
+    element.addEventListener(event2, () => without_reactive_context(handler));
+    const prev2 = element.__on_r;
+    if (prev2) {
+      element.__on_r = () => {
+        prev2();
+        on_reset(true);
+      };
+    } else {
+      element.__on_r = () => on_reset(true);
+    }
+    add_form_reset_listener();
+  }
   const all_registered_events = /* @__PURE__ */ new Set();
   const root_event_handles = /* @__PURE__ */ new Set();
-  function create_event(event_name, dom, handler, options) {
+  function create_event(event_name, dom, handler, options = {}) {
     function target_handler(event2) {
       if (!options.capture) {
         handle_event_propagation.call(dom, event2);
       }
       if (!event2.cancelBubble) {
-        var previous_reaction = active_reaction;
-        var previous_effect = active_effect;
-        set_active_reaction(null);
-        set_active_effect(null);
-        try {
-          return handler.call(this, event2);
-        } finally {
-          set_active_reaction(previous_reaction);
-          set_active_effect(previous_effect);
-        }
+        return without_reactive_context(() => {
+          return handler == null ? void 0 : handler.call(this, event2);
+        });
       }
     }
     if (event_name.startsWith("pointer") || event_name.startsWith("touch") || event_name === "wheel") {
@@ -1545,10 +2225,13 @@
     }
     return target_handler;
   }
-  function event(event_name, dom, handler, capture, passive) {
-    var options = { capture, passive };
+  function event(event_name, dom, handler, capture2, passive) {
+    var options = { capture: capture2, passive };
     var target_handler = create_event(event_name, dom, handler, options);
-    if (dom === document.body || dom === window || dom === document) {
+    if (dom === document.body || // @ts-ignore
+    dom === window || // @ts-ignore
+    dom === document || // Firefox has quirky behavior, it can happen that we still get "canplay" events when the element is already removed
+    dom instanceof HTMLMediaElement) {
       teardown(() => {
         dom.removeEventListener(event_name, target_handler, options);
       });
@@ -1563,14 +2246,14 @@
     }
   }
   function handle_event_propagation(event2) {
-    var _a;
+    var _a2;
     var handler_element = this;
     var owner_document = (
       /** @type {Node} */
       handler_element.ownerDocument
     );
     var event_name = event2.type;
-    var path = ((_a = event2.composedPath) == null ? void 0 : _a.call(event2)) || [];
+    var path = ((_a2 = event2.composedPath) == null ? void 0 : _a2.call(event2)) || [];
     var current_target = (
       /** @type {null | Element} */
       path[0] || event2.target
@@ -1613,8 +2296,10 @@
         current_target.host || null;
         try {
           var delegated = current_target["__" + event_name];
-          if (delegated !== void 0 && !/** @type {any} */
-          current_target.disabled) {
+          if (delegated != null && (!/** @type {any} */
+          current_target.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
+          // -> the target could not have been disabled because it emits the event in the first place
+          event2.target === current_target)) {
             if (is_array(delegated)) {
               var [fn, ...data] = delegated;
               fn.apply(current_target, [event2, ...data]);
@@ -1651,7 +2336,7 @@
   }
   function create_fragment_from_html(html2) {
     var elem = document.createElement("template");
-    elem.innerHTML = html2;
+    elem.innerHTML = html2.replaceAll("<!>", "<!---->");
     return elem.content;
   }
   function assign_nodes(start, end) {
@@ -1665,7 +2350,7 @@
     }
   }
   // @__NO_SIDE_EFFECTS__
-  function template(content, flags) {
+  function from_html(content, flags) {
     var is_fragment = (flags & TEMPLATE_FRAGMENT) !== 0;
     var use_import_node = (flags & TEMPLATE_USE_IMPORT_NODE) !== 0;
     var node;
@@ -1678,7 +2363,7 @@
       }
       var clone = (
         /** @type {TemplateNode} */
-        use_import_node ? document.importNode(node, true) : node.cloneNode(true)
+        use_import_node || is_firefox ? document.importNode(node, true) : node.cloneNode(true)
       );
       if (is_fragment) {
         var start = (
@@ -1713,16 +2398,12 @@
       dom
     );
   }
-  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
-  function is_passive_event(name) {
-    return PASSIVE_EVENTS.includes(name);
-  }
   let should_intro = true;
   function set_text(text, value) {
     var str = value == null ? "" : typeof value === "object" ? value + "" : value;
     if (str !== (text.__t ?? (text.__t = text.nodeValue))) {
       text.__t = str;
-      text.nodeValue = str == null ? "" : str + "";
+      text.nodeValue = str + "";
     }
   }
   function mount(component, options) {
@@ -1751,7 +2432,7 @@
     event_handle(array_from(all_registered_events));
     root_event_handles.add(event_handle);
     var component = void 0;
-    var unmount = effect_root(() => {
+    var unmount = component_root(() => {
       var anchor_node = anchor ?? target.appendChild(create_text());
       branch(() => {
         if (context) {
@@ -1773,7 +2454,7 @@
         }
       });
       return () => {
-        var _a;
+        var _a2;
         for (var event_name of registered_events) {
           target.removeEventListener(event_name, handle_event_propagation);
           var n = (
@@ -1788,9 +2469,8 @@
           }
         }
         root_event_handles.delete(event_handle);
-        mounted_components.delete(component);
         if (anchor_node !== anchor) {
-          (_a = anchor_node.parentNode) == null ? void 0 : _a.removeChild(anchor_node);
+          (_a2 = anchor_node.parentNode) == null ? void 0 : _a2.removeChild(anchor_node);
         }
       };
     });
@@ -1805,15 +2485,20 @@
     var anchor = node;
     var runes = is_runes();
     var active_component_context = component_context;
-    var input;
+    var input = UNINITIALIZED;
     var pending_effect;
     var then_effect;
     var catch_effect;
-    var input_source = (runes ? source : mutable_source)(
+    var input_source = runes ? source(
       /** @type {V} */
       void 0
+    ) : /* @__PURE__ */ mutable_source(
+      /** @type {V} */
+      void 0,
+      false,
+      false
     );
-    var error_source = (runes ? source : mutable_source)(void 0);
+    var error_source = runes ? source(void 0) : /* @__PURE__ */ mutable_source(void 0, false, false);
     var resolved = false;
     function update(state2, restore) {
       resolved = true;
@@ -1822,32 +2507,35 @@
         set_active_reaction(effect2);
         set_component_context(active_component_context);
       }
-      if (state2 === PENDING && pending_fn) {
-        if (pending_effect) resume_effect(pending_effect);
-        else pending_effect = branch(() => pending_fn(anchor));
-      }
-      if (state2 === THEN && then_fn) {
-        if (then_effect) resume_effect(then_effect);
-        else then_effect = branch(() => then_fn(anchor, input_source));
-      }
-      if (state2 === CATCH && catch_fn) {
-        if (catch_effect) resume_effect(catch_effect);
-        else catch_effect = branch(() => catch_fn(anchor, error_source));
-      }
-      if (state2 !== PENDING && pending_effect) {
-        pause_effect(pending_effect, () => pending_effect = null);
-      }
-      if (state2 !== THEN && then_effect) {
-        pause_effect(then_effect, () => then_effect = null);
-      }
-      if (state2 !== CATCH && catch_effect) {
-        pause_effect(catch_effect, () => catch_effect = null);
-      }
-      if (restore) {
-        set_component_context(null);
-        set_active_reaction(null);
-        set_active_effect(null);
-        flush_sync();
+      try {
+        if (state2 === PENDING && pending_fn) {
+          if (pending_effect) resume_effect(pending_effect);
+          else pending_effect = branch(() => pending_fn(anchor));
+        }
+        if (state2 === THEN && then_fn) {
+          if (then_effect) resume_effect(then_effect);
+          else then_effect = branch(() => then_fn(anchor, input_source));
+        }
+        if (state2 === CATCH && catch_fn) {
+          if (catch_effect) resume_effect(catch_effect);
+          else catch_effect = branch(() => catch_fn(anchor, error_source));
+        }
+        if (state2 !== PENDING && pending_effect) {
+          pause_effect(pending_effect, () => pending_effect = null);
+        }
+        if (state2 !== THEN && then_effect) {
+          pause_effect(then_effect, () => then_effect = null);
+        }
+        if (state2 !== CATCH && catch_effect) {
+          pause_effect(catch_effect, () => catch_effect = null);
+        }
+      } finally {
+        if (restore) {
+          set_component_context(null);
+          set_active_reaction(null);
+          set_active_effect(null);
+          flushSync();
+        }
       }
     }
     var effect2 = block(() => {
@@ -1879,47 +2567,61 @@
         internal_set(input_source, input);
         update(THEN, false);
       }
-      return () => input = null;
+      return () => input = UNINITIALIZED;
     });
   }
-  function if_block(node, get_condition, consequent_fn, alternate_fn = null, elseif = false) {
+  function if_block(node, fn, elseif = false) {
     var anchor = node;
     var consequent_effect = null;
     var alternate_effect = null;
-    var condition = null;
+    var condition = UNINITIALIZED;
     var flags = elseif ? EFFECT_TRANSPARENT : 0;
-    block(() => {
-      if (condition === (condition = !!get_condition())) return;
-      if (condition) {
-        if (consequent_effect) {
-          resume_effect(consequent_effect);
-        } else {
-          consequent_effect = branch(() => consequent_fn(anchor));
-        }
-        if (alternate_effect) {
-          pause_effect(alternate_effect, () => {
+    var has_branch = false;
+    const set_branch = (fn2, flag = true) => {
+      has_branch = true;
+      update_branch(flag, fn2);
+    };
+    function commit() {
+      var active = condition ? consequent_effect : alternate_effect;
+      var inactive = condition ? alternate_effect : consequent_effect;
+      if (active) {
+        resume_effect(active);
+      }
+      if (inactive) {
+        pause_effect(inactive, () => {
+          if (condition) {
             alternate_effect = null;
-          });
-        }
-      } else {
-        if (alternate_effect) {
-          resume_effect(alternate_effect);
-        } else if (alternate_fn) {
-          alternate_effect = branch(() => alternate_fn(anchor));
-        }
-        if (consequent_effect) {
-          pause_effect(consequent_effect, () => {
+          } else {
             consequent_effect = null;
-          });
-        }
+          }
+        });
+      }
+    }
+    const update_branch = (new_condition, fn2) => {
+      if (condition === (condition = new_condition)) return;
+      var target = anchor;
+      if (condition) {
+        consequent_effect ?? (consequent_effect = fn2 && branch(() => fn2(target)));
+      } else {
+        alternate_effect ?? (alternate_effect = fn2 && branch(() => fn2(target)));
+      }
+      {
+        commit();
+      }
+    };
+    block(() => {
+      has_branch = false;
+      fn(set_branch);
+      if (!has_branch) {
+        update_branch(null, null);
       }
     }, flags);
   }
-  let current_each_item = null;
   function index(_, i) {
     return i;
   }
-  function pause_effects(state2, items, controlled_anchor, items_map) {
+  function pause_effects(state2, items, controlled_anchor) {
+    var items_map = state2.items;
     var transitions = [];
     var length = items.length;
     for (var i = 0; i < length; i++) {
@@ -1964,19 +2666,27 @@
     }
     var fallback = null;
     var was_empty = false;
-    block(() => {
+    var offscreen_items = /* @__PURE__ */ new Map();
+    var each_array = /* @__PURE__ */ derived_safe_equal(() => {
       var collection = get_collection();
-      var array = is_array(collection) ? collection : collection == null ? [] : array_from(collection);
-      var length = array.length;
-      if (was_empty && length === 0) {
-        return;
-      }
-      was_empty = length === 0;
-      {
-        reconcile(array, state2, anchor, render_fn, flags, get_key);
-      }
+      return is_array(collection) ? collection : collection == null ? [] : array_from(collection);
+    });
+    var array;
+    var each_effect;
+    function commit() {
+      reconcile(
+        each_effect,
+        array,
+        state2,
+        offscreen_items,
+        anchor,
+        render_fn,
+        flags,
+        get_key,
+        get_collection
+      );
       if (fallback_fn !== null) {
-        if (length === 0) {
+        if (array.length === 0) {
           if (fallback) {
             resume_effect(fallback);
           } else {
@@ -1988,11 +2698,26 @@
           });
         }
       }
-      get_collection();
+    }
+    block(() => {
+      each_effect ?? (each_effect = /** @type {Effect} */
+      active_effect);
+      array = get(each_array);
+      var length = array.length;
+      if (was_empty && length === 0) {
+        return;
+      }
+      was_empty = length === 0;
+      {
+        {
+          commit();
+        }
+      }
+      get(each_array);
     });
   }
-  function reconcile(array, state2, anchor, render_fn, flags, get_key) {
-    var _a, _b, _c, _d;
+  function reconcile(each_effect, array, state2, offscreen_items, anchor, render_fn, flags, get_key, get_collection) {
+    var _a2, _b, _c, _d;
     var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
     var should_update = (flags & (EACH_ITEM_REACTIVE | EACH_INDEX_REACTIVE)) !== 0;
     var length = array.length;
@@ -2014,7 +2739,7 @@
         key = get_key(value, i);
         item = items.get(key);
         if (item !== void 0) {
-          (_a = item.a) == null ? void 0 : _a.measure();
+          (_a2 = item.a) == null ? void 0 : _a2.measure();
           (to_animate ?? (to_animate = /* @__PURE__ */ new Set())).add(item);
         }
       }
@@ -2024,21 +2749,33 @@
       key = get_key(value, i);
       item = items.get(key);
       if (item === void 0) {
-        var child_anchor = current ? (
-          /** @type {TemplateNode} */
-          current.e.nodes_start
-        ) : anchor;
-        prev2 = create_item(
-          child_anchor,
-          state2,
-          prev2,
-          prev2 === null ? state2.first : prev2.next,
-          value,
-          key,
-          i,
-          render_fn,
-          flags
-        );
+        var pending = offscreen_items.get(key);
+        if (pending !== void 0) {
+          offscreen_items.delete(key);
+          items.set(key, pending);
+          var next2 = prev2 ? prev2.next : current;
+          link(state2, prev2, pending);
+          link(state2, pending, next2);
+          move(pending, next2, anchor);
+          prev2 = pending;
+        } else {
+          var child_anchor = current ? (
+            /** @type {TemplateNode} */
+            current.e.nodes_start
+          ) : anchor;
+          prev2 = create_item(
+            child_anchor,
+            state2,
+            prev2,
+            prev2 === null ? state2.first : prev2.next,
+            value,
+            key,
+            i,
+            render_fn,
+            flags,
+            get_collection
+          );
+        }
         items.set(key, prev2);
         matched = [];
         stashed = [];
@@ -2124,20 +2861,24 @@
             (_d = to_destroy[i].a) == null ? void 0 : _d.fix();
           }
         }
-        pause_effects(state2, to_destroy, controlled_anchor, items);
+        pause_effects(state2, to_destroy, controlled_anchor);
       }
     }
     if (is_animated) {
       queue_micro_task(() => {
-        var _a2;
+        var _a3;
         if (to_animate === void 0) return;
         for (item of to_animate) {
-          (_a2 = item.a) == null ? void 0 : _a2.apply();
+          (_a3 = item.a) == null ? void 0 : _a3.apply();
         }
       });
     }
-    active_effect.first = state2.first && state2.first.e;
-    active_effect.last = prev2 && prev2.e;
+    each_effect.first = state2.first && state2.first.e;
+    each_effect.last = prev2 && prev2.e;
+    for (var unused of offscreen_items.values()) {
+      destroy_effect(unused.e);
+    }
+    offscreen_items.clear();
   }
   function update_item(item, value, index2, type) {
     if ((type & EACH_ITEM_REACTIVE) !== 0) {
@@ -2153,29 +2894,39 @@
       item.i = index2;
     }
   }
-  function create_item(anchor, state2, prev2, next2, value, key, index2, render_fn, flags) {
-    var previous_each_item = current_each_item;
+  function create_item(anchor, state2, prev2, next2, value, key, index2, render_fn, flags, get_collection, deferred2) {
+    var reactive = (flags & EACH_ITEM_REACTIVE) !== 0;
+    var mutable = (flags & EACH_ITEM_IMMUTABLE) === 0;
+    var v = reactive ? mutable ? /* @__PURE__ */ mutable_source(value, false, false) : source(value) : value;
+    var i = (flags & EACH_INDEX_REACTIVE) === 0 ? index2 : source(index2);
+    var item = {
+      i,
+      v,
+      k: key,
+      a: null,
+      // @ts-expect-error
+      e: null,
+      prev: prev2,
+      next: next2
+    };
     try {
-      var reactive = (flags & EACH_ITEM_REACTIVE) !== 0;
-      var mutable = (flags & EACH_ITEM_IMMUTABLE) === 0;
-      var v = reactive ? mutable ? /* @__PURE__ */ mutable_source(value) : source(value) : value;
-      var i = (flags & EACH_INDEX_REACTIVE) === 0 ? index2 : source(index2);
-      var item = {
-        i,
+      if (anchor === null) {
+        var fragment = document.createDocumentFragment();
+        fragment.append(anchor = create_text());
+      }
+      item.e = branch(() => render_fn(
+        /** @type {Node} */
+        anchor,
         v,
-        k: key,
-        a: null,
-        // @ts-expect-error
-        e: null,
-        prev: prev2,
-        next: next2
-      };
-      current_each_item = item;
-      item.e = branch(() => render_fn(anchor, v, i), hydrating);
+        i,
+        get_collection
+      ), hydrating);
       item.e.prev = prev2 && prev2.e;
       item.e.next = next2 && next2.e;
       if (prev2 === null) {
-        state2.first = item;
+        if (!deferred2) {
+          state2.first = item;
+        }
       } else {
         prev2.next = item;
         prev2.e.next = item.e;
@@ -2186,7 +2937,6 @@
       }
       return item;
     } finally {
-      current_each_item = previous_each_item;
     }
   }
   function move(item, next2, anchor) {
@@ -2202,7 +2952,7 @@
       /** @type {TemplateNode} */
       item.e.nodes_start
     );
-    while (node !== end) {
+    while (node !== null && node !== end) {
       var next_node = (
         /** @type {TemplateNode} */
         /* @__PURE__ */ get_next_sibling(node)
@@ -2223,65 +2973,226 @@
       next2.e.prev = prev2 && prev2.e;
     }
   }
-  function html(node, get_value, svg, mathml, skip_warning) {
+  function html(node, get_value, svg = false, mathml = false, skip_warning = false) {
     var anchor = node;
     var value = "";
-    var effect2;
-    block(() => {
+    template_effect(() => {
+      var effect2 = (
+        /** @type {Effect} */
+        active_effect
+      );
       if (value === (value = get_value() ?? "")) {
         return;
       }
-      if (effect2 !== void 0) {
-        destroy_effect(effect2);
-        effect2 = void 0;
+      if (effect2.nodes_start !== null) {
+        remove_effect_dom(
+          effect2.nodes_start,
+          /** @type {TemplateNode} */
+          effect2.nodes_end
+        );
+        effect2.nodes_start = effect2.nodes_end = null;
       }
       if (value === "") return;
-      effect2 = branch(() => {
-        var html2 = value + "";
-        var node2 = create_fragment_from_html(html2);
-        assign_nodes(
-          /** @type {TemplateNode} */
-          /* @__PURE__ */ get_first_child(node2),
-          /** @type {TemplateNode} */
-          node2.lastChild
-        );
-        {
-          anchor.before(node2);
+      var html2 = value + "";
+      if (svg) html2 = `<svg>${html2}</svg>`;
+      else if (mathml) html2 = `<math>${html2}</math>`;
+      var node2 = create_fragment_from_html(html2);
+      if (svg || mathml) {
+        node2 = /** @type {Element} */
+        /* @__PURE__ */ get_first_child(node2);
+      }
+      assign_nodes(
+        /** @type {TemplateNode} */
+        /* @__PURE__ */ get_first_child(node2),
+        /** @type {TemplateNode} */
+        node2.lastChild
+      );
+      if (svg || mathml) {
+        while (/* @__PURE__ */ get_first_child(node2)) {
+          anchor.before(
+            /** @type {Node} */
+            /* @__PURE__ */ get_first_child(node2)
+          );
         }
-      });
+      } else {
+        anchor.before(node2);
+      }
     });
   }
-  let listening_to_form_reset = false;
-  function add_form_reset_listener() {
-    if (!listening_to_form_reset) {
-      listening_to_form_reset = true;
-      document.addEventListener(
-        "reset",
-        (evt) => {
-          Promise.resolve().then(() => {
-            var _a;
-            if (!evt.defaultPrevented) {
-              for (
-                const e of
-                /**@type {HTMLFormElement} */
-                evt.target.elements
-              ) {
-                (_a = e.__on_r) == null ? void 0 : _a.call(e);
-              }
-            }
-          });
-        },
-        // In the capture phase to guarantee we get noticed of it (no possiblity of stopPropagation)
-        { capture: true }
-      );
+  function r(e) {
+    var t, f, n = "";
+    if ("string" == typeof e || "number" == typeof e) n += e;
+    else if ("object" == typeof e) if (Array.isArray(e)) {
+      var o = e.length;
+      for (t = 0; t < o; t++) e[t] && (f = r(e[t])) && (n && (n += " "), n += f);
+    } else for (f in e) e[f] && (n && (n += " "), n += f);
+    return n;
+  }
+  function clsx$1() {
+    for (var e, t, f = 0, n = "", o = arguments.length; f < o; f++) (e = arguments[f]) && (t = r(e)) && (n && (n += " "), n += t);
+    return n;
+  }
+  function clsx(value) {
+    if (typeof value === "object") {
+      return clsx$1(value);
+    } else {
+      return value ?? "";
     }
   }
-  function set_attribute(element, attribute, value, skip_warning) {
-    var attributes = element.__attributes ?? (element.__attributes = {});
-    if (attributes[attribute] === (attributes[attribute] = value)) return;
-    if (attribute === "style" && "__styles" in element) {
-      element.__styles = {};
+  function to_class(value, hash, directives) {
+    var classname = value == null ? "" : "" + value;
+    if (hash) {
+      classname = classname ? classname + " " + hash : hash;
     }
+    return classname === "" ? null : classname;
+  }
+  function append_styles(styles, important = false) {
+    var separator = important ? " !important;" : ";";
+    var css = "";
+    for (var key in styles) {
+      var value = styles[key];
+      if (value != null && value !== "") {
+        css += " " + key + ": " + value + separator;
+      }
+    }
+    return css;
+  }
+  function to_css_name(name) {
+    if (name[0] !== "-" || name[1] !== "-") {
+      return name.toLowerCase();
+    }
+    return name;
+  }
+  function to_style(value, styles) {
+    if (styles) {
+      var new_style = "";
+      var normal_styles;
+      var important_styles;
+      if (Array.isArray(styles)) {
+        normal_styles = styles[0];
+        important_styles = styles[1];
+      } else {
+        normal_styles = styles;
+      }
+      if (value) {
+        value = String(value).replaceAll(/\s*\/\*.*?\*\/\s*/g, "").trim();
+        var in_str = false;
+        var in_apo = 0;
+        var in_comment = false;
+        var reserved_names = [];
+        if (normal_styles) {
+          reserved_names.push(...Object.keys(normal_styles).map(to_css_name));
+        }
+        if (important_styles) {
+          reserved_names.push(...Object.keys(important_styles).map(to_css_name));
+        }
+        var start_index = 0;
+        var name_index = -1;
+        const len = value.length;
+        for (var i = 0; i < len; i++) {
+          var c = value[i];
+          if (in_comment) {
+            if (c === "/" && value[i - 1] === "*") {
+              in_comment = false;
+            }
+          } else if (in_str) {
+            if (in_str === c) {
+              in_str = false;
+            }
+          } else if (c === "/" && value[i + 1] === "*") {
+            in_comment = true;
+          } else if (c === '"' || c === "'") {
+            in_str = c;
+          } else if (c === "(") {
+            in_apo++;
+          } else if (c === ")") {
+            in_apo--;
+          }
+          if (!in_comment && in_str === false && in_apo === 0) {
+            if (c === ":" && name_index === -1) {
+              name_index = i;
+            } else if (c === ";" || i === len - 1) {
+              if (name_index !== -1) {
+                var name = to_css_name(value.substring(start_index, name_index).trim());
+                if (!reserved_names.includes(name)) {
+                  if (c !== ";") {
+                    i++;
+                  }
+                  var property = value.substring(start_index, i).trim();
+                  new_style += " " + property + ";";
+                }
+              }
+              start_index = i + 1;
+              name_index = -1;
+            }
+          }
+        }
+      }
+      if (normal_styles) {
+        new_style += append_styles(normal_styles);
+      }
+      if (important_styles) {
+        new_style += append_styles(important_styles, true);
+      }
+      new_style = new_style.trim();
+      return new_style === "" ? null : new_style;
+    }
+    return value == null ? null : String(value);
+  }
+  function set_class(dom, is_html, value, hash, prev_classes, next_classes) {
+    var prev2 = dom.__className;
+    if (prev2 !== value || prev2 === void 0) {
+      var next_class_name = to_class(value, hash);
+      {
+        if (next_class_name == null) {
+          dom.removeAttribute("class");
+        } else {
+          dom.className = next_class_name;
+        }
+      }
+      dom.__className = value;
+    }
+    return next_classes;
+  }
+  function update_styles(dom, prev2 = {}, next2, priority) {
+    for (var key in next2) {
+      var value = next2[key];
+      if (prev2[key] !== value) {
+        if (next2[key] == null) {
+          dom.style.removeProperty(key);
+        } else {
+          dom.style.setProperty(key, value, priority);
+        }
+      }
+    }
+  }
+  function set_style(dom, value, prev_styles, next_styles) {
+    var prev2 = dom.__style;
+    if (prev2 !== value) {
+      var next_style_attr = to_style(value, next_styles);
+      {
+        if (next_style_attr == null) {
+          dom.removeAttribute("style");
+        } else {
+          dom.style.cssText = next_style_attr;
+        }
+      }
+      dom.__style = value;
+    } else if (next_styles) {
+      if (Array.isArray(next_styles)) {
+        update_styles(dom, prev_styles == null ? void 0 : prev_styles[0], next_styles[0]);
+        update_styles(dom, prev_styles == null ? void 0 : prev_styles[1], next_styles[1], "important");
+      } else {
+        update_styles(dom, prev_styles, next_styles);
+      }
+    }
+    return next_styles;
+  }
+  const IS_CUSTOM_ELEMENT = Symbol("is custom element");
+  const IS_HTML = Symbol("is html");
+  function set_attribute(element, attribute, value, skip_warning) {
+    var attributes = get_attributes(element);
+    if (attributes[attribute] === (attributes[attribute] = value)) return;
     if (attribute === "loading") {
       element[LOADING_ATTR_SYMBOL] = value;
     }
@@ -2293,13 +3204,23 @@
       element.setAttribute(attribute, value);
     }
   }
+  function get_attributes(element) {
+    return (
+      /** @type {Record<string | symbol, unknown>} **/
+      // @ts-expect-error
+      element.__attributes ?? (element.__attributes = {
+        [IS_CUSTOM_ELEMENT]: element.nodeName.includes("-"),
+        [IS_HTML]: element.namespaceURI === NAMESPACE_HTML
+      })
+    );
+  }
   var setters_cache = /* @__PURE__ */ new Map();
   function get_setters(element) {
     var setters = setters_cache.get(element.nodeName);
     if (setters) return setters;
     setters_cache.set(element.nodeName, setters = []);
     var descriptors;
-    var proto = get_prototype_of(element);
+    var proto = element;
     var element_proto = Element.prototype;
     while (element_proto !== proto) {
       descriptors = get_descriptors(proto);
@@ -2312,44 +3233,20 @@
     }
     return setters;
   }
-  function set_class(dom, value) {
-    var prev_class_name = dom.__className;
-    var next_class_name = to_class(value);
-    if (prev_class_name !== next_class_name || hydrating) {
-      if (value == null) {
-        dom.removeAttribute("class");
-      } else {
-        dom.className = next_class_name;
-      }
-      dom.__className = next_class_name;
-    }
-  }
-  function to_class(value) {
-    return value == null ? "" : value;
-  }
-  function set_style(dom, key, value, important) {
-    var styles = dom.__styles ?? (dom.__styles = {});
-    if (styles[key] === value) {
-      return;
-    }
-    styles[key] = value;
-    if (value == null) {
-      dom.style.removeProperty(key);
-    } else {
-      dom.style.setProperty(key, value, "");
-    }
-  }
-  const request_animation_frame = requestAnimationFrame;
   const now = () => performance.now();
   const raf = {
+    // don't access requestAnimationFrame eagerly outside method
+    // this allows basic testing of user code without JSDOM
+    // bunder will eval and remove ternary when the user's app is built
     tick: (
       /** @param {any} _ */
-      (_) => request_animation_frame(_)
+      (_) => requestAnimationFrame(_)
     ),
     now: () => now(),
     tasks: /* @__PURE__ */ new Set()
   };
-  function run_tasks(now2) {
+  function run_tasks() {
+    const now2 = raf.now();
     raf.tasks.forEach((task) => {
       if (!task.c(now2)) {
         raf.tasks.delete(task);
@@ -2375,7 +3272,9 @@
     };
   }
   function dispatch_event(element, type) {
-    element.dispatchEvent(new CustomEvent(type));
+    without_reactive_context(() => {
+      element.dispatchEvent(new CustomEvent(type));
+    });
   }
   function css_property_to_camelcase(style) {
     if (style === "float") return "cssFloat";
@@ -2408,31 +3307,25 @@
     var direction = is_both ? "both" : is_intro ? "in" : "out";
     var current_options;
     var inert = element.inert;
+    var overflow = element.style.overflow;
     var intro;
     var outro;
     function get_options() {
-      var previous_reaction = active_reaction;
-      var previous_effect = active_effect;
-      set_active_reaction(null);
-      set_active_effect(null);
-      try {
+      return without_reactive_context(() => {
         return current_options ?? (current_options = get_fn()(element, (get_params == null ? void 0 : get_params()) ?? /** @type {P} */
         {}, {
           direction
         }));
-      } finally {
-        set_active_reaction(previous_reaction);
-        set_active_effect(previous_effect);
-      }
+      });
     }
     var transition2 = {
       is_global,
       in() {
-        var _a;
+        var _a2;
         element.inert = inert;
         if (!is_intro) {
           outro == null ? void 0 : outro.abort();
-          (_a = outro == null ? void 0 : outro.reset) == null ? void 0 : _a.call(outro);
+          (_a2 = outro == null ? void 0 : outro.reset) == null ? void 0 : _a2.call(outro);
           return;
         }
         if (!is_outro) {
@@ -2443,6 +3336,7 @@
           dispatch_event(element, "introend");
           intro == null ? void 0 : intro.abort();
           intro = current_options = void 0;
+          element.style.overflow = overflow;
         });
       },
       out(fn) {
@@ -2531,8 +3425,9 @@
       }
     }
     var get_t = () => 1 - t2;
-    var animation = element.animate(keyframes, { duration: delay });
+    var animation = element.animate(keyframes, { duration: delay, fill: "forwards" });
     animation.onfinish = () => {
+      animation.cancel();
       var t1 = (counterpart == null ? void 0 : counterpart.t()) ?? 1 - t2;
       counterpart == null ? void 0 : counterpart.abort();
       var delta = t2 - t1;
@@ -2542,13 +3437,18 @@
       );
       var keyframes2 = [];
       if (duration > 0) {
+        var needs_overflow_hidden = false;
         if (css) {
           var n = Math.ceil(duration / (1e3 / 60));
           for (var i = 0; i <= n; i += 1) {
             var t = t1 + delta * easing(i / n);
-            var styles2 = css(t, 1 - t);
-            keyframes2.push(css_to_keyframe(styles2));
+            var styles2 = css_to_keyframe(css(t, 1 - t));
+            keyframes2.push(styles2);
+            needs_overflow_hidden || (needs_overflow_hidden = styles2.overflow === "hidden");
           }
+        }
+        if (needs_overflow_hidden) {
+          element.style.overflow = "hidden";
         }
         get_t = () => {
           var time = (
@@ -2593,30 +3493,46 @@
       t: () => get_t()
     };
   }
-  function listen_to_event_and_reset_event(element, event2, handler, on_reset = handler) {
-    element.addEventListener(event2, handler);
-    const prev2 = element.__on_r;
-    if (prev2) {
-      element.__on_r = () => {
-        prev2();
-        on_reset();
-      };
-    } else {
-      element.__on_r = on_reset;
-    }
-    add_form_reset_listener();
-  }
   function bind_value(input, get2, set2 = get2) {
     var runes = is_runes();
-    listen_to_event_and_reset_event(input, "input", () => {
-      var value = is_numberlike_input(input) ? to_number(input.value) : input.value;
+    var batches2 = /* @__PURE__ */ new WeakSet();
+    listen_to_event_and_reset_event(input, "input", (is_reset) => {
+      var value = is_reset ? input.defaultValue : input.value;
+      value = is_numberlike_input(input) ? to_number(value) : value;
       set2(value);
+      if (current_batch !== null) {
+        batches2.add(current_batch);
+      }
       if (runes && value !== (value = get2())) {
+        var start = input.selectionStart;
+        var end = input.selectionEnd;
         input.value = value ?? "";
+        if (end !== null) {
+          input.selectionStart = start;
+          input.selectionEnd = Math.min(end, input.value.length);
+        }
       }
     });
+    if (
+      // If we are hydrating and the value has since changed,
+      // then use the updated value from the input instead.
+      // If defaultValue is set, then value == defaultValue
+      // TODO Svelte 6: remove input.value check and set to empty string?
+      untrack(get2) == null && input.value
+    ) {
+      set2(is_numberlike_input(input) ? to_number(input.value) : input.value);
+      if (current_batch !== null) {
+        batches2.add(current_batch);
+      }
+    }
     render_effect(() => {
       var value = get2();
+      if (input === document.activeElement && batches2.has(
+        /** @type {Batch} */
+        current_batch
+      )) {
+        return;
+      }
       if (is_numberlike_input(input) && value === to_number(input.value)) {
         return;
       }
@@ -2663,6 +3579,16 @@
       };
     });
     return element_or_component;
+  }
+  function stopPropagation(fn) {
+    return function(...args) {
+      var event2 = (
+        /** @type {Event} */
+        args[0]
+      );
+      event2.stopPropagation();
+      return fn == null ? void 0 : fn.apply(this, args);
+    };
   }
   function init(immutable = false) {
     const context = (
@@ -2721,6 +3647,17 @@
     }
     props();
   }
+  function bubble_event($$props, event2) {
+    var _a2;
+    var events = (
+      /** @type {Record<string, Function[] | Function>} */
+      (_a2 = $$props.$$events) == null ? void 0 : _a2[event2.type]
+    );
+    var callbacks = is_array(events) ? events.slice() : events == null ? [] : [events];
+    for (var fn of callbacks) {
+      fn.call(this, event2);
+    }
+  }
   let is_store_binding = false;
   function capture_store_binding(fn) {
     var previous_is_store_binding = is_store_binding;
@@ -2731,65 +3668,51 @@
       is_store_binding = previous_is_store_binding;
     }
   }
-  function with_parent_branch(fn) {
-    var effect2 = active_effect;
-    var previous_effect = active_effect;
-    while (effect2 !== null && (effect2.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
-      effect2 = effect2.parent;
-    }
-    try {
-      set_active_effect(effect2);
-      return fn();
-    } finally {
-      set_active_effect(previous_effect);
-    }
-  }
   function prop(props, key, flags, fallback) {
-    var _a;
-    var immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
-    var runes = (flags & PROPS_IS_RUNES) !== 0;
+    var _a2;
+    var runes = !legacy_mode_flag || (flags & PROPS_IS_RUNES) !== 0;
     var bindable = (flags & PROPS_IS_BINDABLE) !== 0;
     var lazy = (flags & PROPS_IS_LAZY_INITIAL) !== 0;
-    var is_store_sub = false;
-    var prop_value;
-    if (bindable) {
-      [prop_value, is_store_sub] = capture_store_binding(() => (
-        /** @type {V} */
-        props[key]
-      ));
-    } else {
-      prop_value = /** @type {V} */
-      props[key];
-    }
-    var setter = (_a = get_descriptor(props, key)) == null ? void 0 : _a.set;
     var fallback_value = (
       /** @type {V} */
       fallback
     );
     var fallback_dirty = true;
-    var fallback_used = false;
     var get_fallback = () => {
-      fallback_used = true;
       if (fallback_dirty) {
         fallback_dirty = false;
-        if (lazy) {
-          fallback_value = untrack(
-            /** @type {() => V} */
-            fallback
-          );
-        } else {
-          fallback_value = /** @type {V} */
-          fallback;
-        }
+        fallback_value = lazy ? untrack(
+          /** @type {() => V} */
+          fallback
+        ) : (
+          /** @type {V} */
+          fallback
+        );
       }
       return fallback_value;
     };
-    if (prop_value === void 0 && fallback !== void 0) {
-      if (setter && runes) {
-        props_invalid_value();
+    var setter;
+    if (bindable) {
+      var is_entry_props = STATE_SYMBOL in props || LEGACY_PROPS in props;
+      setter = ((_a2 = get_descriptor(props, key)) == null ? void 0 : _a2.set) ?? (is_entry_props && key in props ? (v) => props[key] = v : void 0);
+    }
+    var initial_value;
+    var is_store_sub = false;
+    if (bindable) {
+      [initial_value, is_store_sub] = capture_store_binding(() => (
+        /** @type {V} */
+        props[key]
+      ));
+    } else {
+      initial_value = /** @type {V} */
+      props[key];
+    }
+    if (initial_value === void 0 && fallback !== void 0) {
+      initial_value = get_fallback();
+      if (setter) {
+        if (runes) props_invalid_value();
+        setter(initial_value);
       }
-      prop_value = get_fallback();
-      if (setter) setter(prop_value);
     }
     var getter;
     if (runes) {
@@ -2800,25 +3723,22 @@
         );
         if (value === void 0) return get_fallback();
         fallback_dirty = true;
-        fallback_used = false;
         return value;
       };
     } else {
-      var derived_getter = with_parent_branch(
-        () => (immutable ? derived : derived_safe_equal)(() => (
+      getter = () => {
+        var value = (
           /** @type {V} */
           props[key]
-        ))
-      );
-      derived_getter.f |= LEGACY_DERIVED_PROP;
-      getter = () => {
-        var value = get(derived_getter);
-        if (value !== void 0) fallback_value = /** @type {V} */
-        void 0;
+        );
+        if (value !== void 0) {
+          fallback_value = /** @type {V} */
+          void 0;
+        }
         return value === void 0 ? fallback_value : value;
       };
     }
-    if ((flags & PROPS_IS_UPDATED) === 0) {
+    if (runes && (flags & PROPS_IS_UPDATED) === 0) {
       return getter;
     }
     if (setter) {
@@ -2829,53 +3749,41 @@
             setter(mutation ? getter() : value);
           }
           return value;
-        } else {
-          return getter();
         }
+        return getter();
       };
     }
-    var from_child = false;
-    var was_from_child = false;
-    var inner_current_value = /* @__PURE__ */ mutable_source(prop_value);
-    var current_value = with_parent_branch(
-      () => /* @__PURE__ */ derived(() => {
-        var parent_value = getter();
-        var child_value = get(inner_current_value);
-        var current_derived = (
-          /** @type {Derived} */
-          active_reaction
-        );
-        if (from_child || parent_value === void 0 && (current_derived.f & DESTROYED) !== 0) {
-          from_child = false;
-          was_from_child = true;
-          return child_value;
-        }
-        was_from_child = false;
-        return inner_current_value.v = parent_value;
-      })
+    var overridden = false;
+    var d = ((flags & PROPS_IS_IMMUTABLE) !== 0 ? derived : derived_safe_equal)(() => {
+      overridden = false;
+      return getter();
+    });
+    if (bindable) get(d);
+    var parent_effect = (
+      /** @type {Effect} */
+      active_effect
     );
-    if (!immutable) current_value.equals = safe_equals;
     return function(value, mutation) {
       if (arguments.length > 0) {
-        const new_value = mutation ? get(current_value) : runes && bindable ? proxy(value) : value;
-        if (!current_value.equals(new_value)) {
-          from_child = true;
-          set(inner_current_value, new_value);
-          if (fallback_used && fallback_value !== void 0) {
-            fallback_value = new_value;
-          }
-          untrack(() => get(current_value));
+        const new_value = mutation ? get(d) : runes && bindable ? proxy(value) : value;
+        set(d, new_value);
+        overridden = true;
+        if (fallback_value !== void 0) {
+          fallback_value = new_value;
         }
         return value;
       }
-      return get(current_value);
+      if (is_destroying_effect && overridden || (parent_effect.f & DESTROYED) !== 0) {
+        return d.v;
+      }
+      return get(d);
     };
   }
   function onMount(fn) {
     if (component_context === null) {
       lifecycle_outside_component();
     }
-    if (component_context.l !== null) {
+    if (legacy_mode_flag && component_context.l !== null) {
       init_update_callbacks(component_context).m.push(fn);
     } else {
       user_effect(() => {
@@ -2895,14 +3803,16 @@
     return l.u ?? (l.u = { a: [], b: [], m: [] });
   }
   const PUBLIC_VERSION = "5";
-  if (typeof window !== "undefined")
-    (window.__svelte || (window.__svelte = { v: /* @__PURE__ */ new Set() })).v.add(PUBLIC_VERSION);
-  var root$5 = /* @__PURE__ */ template(`<div class="loadership_ZOJAQ svelte-i1jlc0"><div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div></div>`);
+  if (typeof window !== "undefined") {
+    ((_a = window.__svelte ?? (window.__svelte = {})).v ?? (_a.v = /* @__PURE__ */ new Set())).add(PUBLIC_VERSION);
+  }
+  enable_legacy_mode_flag();
+  var root$6 = /* @__PURE__ */ from_html(`<div class="loadership_ZOJAQ svelte-i1jlc0"><div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$5();
+    var div = root$6();
     append($$anchor, div);
   }
-  var root_1$1 = /* @__PURE__ */ template(`<img class="fi svelte-7lhsry">`);
+  var root_1$2 = /* @__PURE__ */ from_html(`<img class="fi svelte-7lhsry"/>`);
   function CountryFlag($$anchor, $$props) {
     const countryCodes = {
       Afghanistan: "af",
@@ -3108,12 +4018,22 @@
     const countryCode = countryCodes[$$props.countryName];
     var fragment = comment();
     var node = first_child(fragment);
-    if_block(node, () => countryCode, ($$anchor2) => {
-      var img = root_1$1();
-      template_effect(() => set_attribute(img, "src", `https://purecatamphetamine.github.io/country-flag-icons/3x2/${countryCode.toUpperCase() ?? ""}.svg`));
-      template_effect(() => set_attribute(img, "alt", $$props.countryName));
-      append($$anchor2, img);
-    });
+    {
+      var consequent = ($$anchor2) => {
+        var img = root_1$2();
+        template_effect(
+          ($0) => {
+            set_attribute(img, "alt", $$props.countryName);
+            set_attribute(img, "src", `https://purecatamphetamine.github.io/country-flag-icons/3x2/${$0 ?? ""}.svg`);
+          },
+          [() => countryCode.toUpperCase()]
+        );
+        append($$anchor2, img);
+      };
+      if_block(node, ($$render) => {
+        if (countryCode) $$render(consequent);
+      });
+    }
     append($$anchor, fragment);
   }
   const leftKey = "geometa:containerStyleLeft";
@@ -3200,20 +4120,20 @@
     set(lensX, event2.clientX - rect.left);
     set(lensY, event2.clientY - rect.top);
   }
-  var root_4 = /* @__PURE__ */ template(`<div class="lens svelte-fofh7f"></div>`);
-  var root_3$1 = /* @__PURE__ */ template(`<div class="image-wrapper svelte-fofh7f" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-fofh7f"> <!></div>`);
-  var root_6$1 = /* @__PURE__ */ template(`<button></button>`);
-  var root_5$1 = /* @__PURE__ */ template(`<div class="controls"><button class="click-area prev-area svelte-fofh7f" type="button" aria-label="Previous image"><span class="prev svelte-fofh7f">&#10094;</span></button> <button class="click-area next-area svelte-fofh7f" type="button" aria-label="Next image"><span class="next svelte-fofh7f">&#10095;</span></button></div> <div class="indicators svelte-fofh7f"></div>`, 1);
-  var root$4 = /* @__PURE__ */ template(`<div class="carousel svelte-fofh7f"><!> <!></div>`);
+  var root_4 = /* @__PURE__ */ from_html(`<div class="lens svelte-fofh7f"></div>`);
+  var root_3$1 = /* @__PURE__ */ from_html(`<div class="image-wrapper svelte-fofh7f" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-fofh7f"/> <!></div>`);
+  var root_6$1 = /* @__PURE__ */ from_html(`<button></button>`);
+  var root_5$1 = /* @__PURE__ */ from_html(`<div class="controls"><button class="click-area prev-area svelte-fofh7f" type="button" aria-label="Previous image"><span class="prev svelte-fofh7f">&#10094;</span></button> <button class="click-area next-area svelte-fofh7f" type="button" aria-label="Next image"><span class="next svelte-fofh7f">&#10095;</span></button></div> <div class="indicators svelte-fofh7f"></div>`, 1);
+  var root$5 = /* @__PURE__ */ from_html(`<div class="carousel svelte-fofh7f"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
-    let currentIndex = mutable_state(0);
-    let containerRef = mutable_state(null);
-    let imageRef = mutable_state(null);
-    let isZoomed = mutable_state(false);
-    let lensX = mutable_state(0);
-    let lensY = mutable_state(0);
+    let currentIndex = /* @__PURE__ */ mutable_source(0);
+    let containerRef = /* @__PURE__ */ mutable_source(null);
+    let imageRef = /* @__PURE__ */ mutable_source(null);
+    let isZoomed = /* @__PURE__ */ mutable_source(false);
+    let lensX = /* @__PURE__ */ mutable_source(0);
+    let lensY = /* @__PURE__ */ mutable_source(0);
     let lensSize = 150;
     let scale = 2;
     function handleMouseEnter() {
@@ -3223,64 +4143,84 @@
       set(isZoomed, false);
     }
     init();
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
-    if_block(node, () => images().length, ($$anchor2) => {
-      var fragment = comment();
-      var node_1 = first_child(fragment);
-      each(node_1, 1, images, index, ($$anchor3, image, index2) => {
-        var fragment_1 = comment();
-        var node_2 = first_child(fragment_1);
-        if_block(node_2, () => index2 === get(currentIndex), ($$anchor4) => {
-          var div_1 = root_3$1();
-          bind_this(div_1, ($$value) => set(containerRef, $$value), () => get(containerRef));
-          div_1.__mousemove = [handleMouseMove, containerRef, lensX, lensY];
-          var img = child(div_1);
-          bind_this(img, ($$value) => set(imageRef, $$value), () => get(imageRef));
-          set_attribute(img, "alt", `Image ${index2 + 1}`);
-          var node_3 = sibling(img, 2);
-          if_block(node_3, () => get(isZoomed) && get(imageRef), ($$anchor5) => {
-            var div_2 = root_4();
-            template_effect(() => set_attribute(div_2, "style", `
+    {
+      var consequent_2 = ($$anchor2) => {
+        var fragment = comment();
+        var node_1 = first_child(fragment);
+        each(node_1, 1, images, index, ($$anchor3, image, index2) => {
+          var fragment_1 = comment();
+          var node_2 = first_child(fragment_1);
+          {
+            var consequent_1 = ($$anchor4) => {
+              var div_1 = root_3$1();
+              div_1.__mousemove = [handleMouseMove, containerRef, lensX, lensY];
+              var img = child(div_1);
+              set_attribute(img, "alt", `Image ${index2 + 1}`);
+              bind_this(img, ($$value) => set(imageRef, $$value), () => get(imageRef));
+              var node_3 = sibling(img, 2);
+              {
+                var consequent = ($$anchor5) => {
+                  var div_2 = root_4();
+                  template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
                 left: ${get(lensX) - lensSize / 2}px;
-                width: ${lensSize}px;
-                height: ${lensSize}px;
+                width: 150px;
+                height: 150px;
                 background-image: url(${get(image) ?? ""});
                 background-repeat: no-repeat;
-                background-size: ${get(imageRef).width * scale}px ${get(imageRef).height * scale}px;
+                background-size: ${(get(imageRef), untrack(() => get(imageRef).width * scale)) ?? ""}px ${(get(imageRef), untrack(() => get(imageRef).height * scale)) ?? ""}px;
                 background-position: ${-(get(lensX) * scale - lensSize / 2)}px ${-(get(lensY) * scale - lensSize / 2)}px;
               `));
-            append($$anchor5, div_2);
-          });
-          template_effect(() => set_attribute(img, "src", get(image)));
-          event("mouseenter", div_1, handleMouseEnter);
-          event("mouseleave", div_1, handleMouseLeave);
-          append($$anchor4, div_1);
+                  append($$anchor5, div_2);
+                };
+                if_block(node_3, ($$render) => {
+                  if (get(isZoomed) && get(imageRef)) $$render(consequent);
+                });
+              }
+              bind_this(div_1, ($$value) => set(containerRef, $$value), () => get(containerRef));
+              template_effect(() => set_attribute(img, "src", get(image)));
+              event("mouseenter", div_1, handleMouseEnter);
+              event("mouseleave", div_1, handleMouseLeave);
+              append($$anchor4, div_1);
+            };
+            if_block(node_2, ($$render) => {
+              if (index2 === get(currentIndex)) $$render(consequent_1);
+            });
+          }
+          append($$anchor3, fragment_1);
         });
-        append($$anchor3, fragment_1);
+        append($$anchor2, fragment);
+      };
+      if_block(node, ($$render) => {
+        if (deep_read_state(images()), untrack(() => images().length)) $$render(consequent_2);
       });
-      append($$anchor2, fragment);
-    });
+    }
     var node_4 = sibling(node, 2);
-    if_block(node_4, () => images().length > 1, ($$anchor2) => {
-      var fragment_2 = root_5$1();
-      var div_3 = first_child(fragment_2);
-      var button = child(div_3);
-      button.__click = [prev, currentIndex, images];
-      var button_1 = sibling(button, 2);
-      button_1.__click = [next, currentIndex, images];
-      var div_4 = sibling(div_3, 2);
-      each(div_4, 5, images, index, ($$anchor3, _, index2) => {
-        var button_2 = root_6$1();
-        set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
-        button_2.__click = () => set(currentIndex, index2);
-        template_effect(() => set_class(button_2, `indicator ${(index2 === get(currentIndex) ? "active" : "") ?? ""} svelte-fofh7f`));
-        append($$anchor3, button_2);
+    {
+      var consequent_3 = ($$anchor2) => {
+        var fragment_2 = root_5$1();
+        var div_3 = first_child(fragment_2);
+        var button = child(div_3);
+        button.__click = [prev, currentIndex, images];
+        var button_1 = sibling(button, 2);
+        button_1.__click = [next, currentIndex, images];
+        var div_4 = sibling(div_3, 2);
+        each(div_4, 5, images, index, ($$anchor3, _, index2) => {
+          var button_2 = root_6$1();
+          set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
+          button_2.__click = () => set(currentIndex, index2);
+          template_effect(() => set_class(button_2, 1, `indicator ${index2 === get(currentIndex) ? "active" : ""}`, "svelte-fofh7f"));
+          append($$anchor3, button_2);
+        });
+        append($$anchor2, fragment_2);
+      };
+      if_block(node_4, ($$render) => {
+        if (deep_read_state(images()), untrack(() => images().length > 1)) $$render(consequent_3);
       });
-      append($$anchor2, fragment_2);
-    });
+    }
     append($$anchor, div);
     pop();
   }
@@ -3388,32 +4328,32 @@
   }
   var on_click = (__3, announcement, lastDismissedTimestamp) => {
     markAnnouncementAsDismissed(get(announcement).timestamp);
-    set(lastDismissedTimestamp, proxy(get(announcement).timestamp));
+    set(lastDismissedTimestamp, get(announcement).timestamp, true);
   };
-  var root_2 = /* @__PURE__ */ template(`<div class="announcement svelte-a3mhc8"><div class="svelte-a3mhc8"><!></div> <button class="vote-close-btn svelte-a3mhc8" aria-label="Dismiss announcement">Dismiss</button></div>`);
-  var root_3 = /* @__PURE__ */ template(`<p class="svelte-a3mhc8"> </p>`);
-  var root_6 = /* @__PURE__ */ template(`<p class="geometa-footer svelte-a3mhc8"><!></p>`);
-  var root_7 = /* @__PURE__ */ template(`<hr class="svelte-a3mhc8"> <!>`, 1);
-  var root_5 = /* @__PURE__ */ template(`<p class="svelte-a3mhc8"><!> <strong class="svelte-a3mhc8"> </strong> </p> <div class="geometa-note svelte-a3mhc8"><!></div> <!> <!>`, 1);
-  var root_9 = /* @__PURE__ */ template(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><p class="svelte-a3mhc8">You are about to open this site in a new tab:</p> <p class="modal-url svelte-a3mhc8"> </p> <div class="modal-buttons svelte-a3mhc8"><button class="proceed-btn svelte-a3mhc8">Continue</button> <button class="close-btn svelte-a3mhc8">Cancel</button></div></div></div>`);
-  var root_11 = /* @__PURE__ */ template(`<p class="outdated svelte-a3mhc8"><strong class="svelte-a3mhc8"> </strong></p>`);
-  var root_10 = /* @__PURE__ */ template(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><div class="help-message svelte-a3mhc8"><!> <p class="svelte-a3mhc8">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-a3mhc8"><li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere on your
+  var root_2 = /* @__PURE__ */ from_html(`<div class="announcement svelte-a3mhc8"><div class="svelte-a3mhc8"><!></div> <button class="vote-close-btn svelte-a3mhc8" aria-label="Dismiss announcement">Dismiss</button></div>`);
+  var root_3 = /* @__PURE__ */ from_html(`<p class="svelte-a3mhc8"> </p>`);
+  var root_6 = /* @__PURE__ */ from_html(`<p class="geometa-footer svelte-a3mhc8"><!></p>`);
+  var root_7 = /* @__PURE__ */ from_html(`<hr class="svelte-a3mhc8"/> <!>`, 1);
+  var root_5 = /* @__PURE__ */ from_html(`<p class="svelte-a3mhc8"><!> <strong class="svelte-a3mhc8"> </strong> </p> <div class="geometa-note svelte-a3mhc8"><!></div> <!> <!>`, 1);
+  var root_9 = /* @__PURE__ */ from_html(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><p class="svelte-a3mhc8">You are about to open this site in a new tab:</p> <p class="modal-url svelte-a3mhc8"> </p> <div class="modal-buttons svelte-a3mhc8"><button class="proceed-btn svelte-a3mhc8">Continue</button> <button class="close-btn svelte-a3mhc8">Cancel</button></div></div></div>`);
+  var root_11 = /* @__PURE__ */ from_html(`<p class="outdated svelte-a3mhc8"><strong class="svelte-a3mhc8"> </strong></p>`);
+  var root_10 = /* @__PURE__ */ from_html(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><div class="help-message svelte-a3mhc8"><!> <p class="svelte-a3mhc8">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-a3mhc8"><li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere on your
               screen.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">View Map meta list:</strong> Click the list icon to see all the metas included in the map you
               are currently playing.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Join the Community:</strong> Click the Discord icon to share feedback, suggest improvements, or
               just say hi!</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-a3mhc8">Close</button></div></div>`);
-  var root$3 = /* @__PURE__ */ template(`<div class="geometa-container svelte-a3mhc8"><!> <div class="flex header svelte-a3mhc8"><h2 class="svelte-a3mhc8">Learnable Meta</h2> <div class="icons svelte-a3mhc8"><a target="_blank" aria-label="List of map metas" class="svelte-a3mhc8"><span class="skill-icons--list svelte-a3mhc8"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-a3mhc8"><span class="flat-color-icons--globe svelte-a3mhc8"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-a3mhc8"><span class="skill-icons--discord svelte-a3mhc8"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-a3mhc8"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root$4 = /* @__PURE__ */ from_html(`<div class="geometa-container svelte-a3mhc8"><!> <div class="flex header svelte-a3mhc8"><h2 class="svelte-a3mhc8">Learnable Meta</h2> <div class="icons svelte-a3mhc8"><a target="_blank" aria-label="List of map metas" class="svelte-a3mhc8"><span class="skill-icons--list svelte-a3mhc8"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-a3mhc8"><span class="flat-color-icons--globe svelte-a3mhc8"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-a3mhc8"><span class="skill-icons--discord svelte-a3mhc8"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-a3mhc8"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
-    let geoInfo = state(null);
-    let error = state(null);
+    let geoInfo = /* @__PURE__ */ state(null);
+    let error = /* @__PURE__ */ state(null);
     let container;
     let header;
     onMount(() => {
-      var _a;
+      var _a2;
       const cacheKey = `${$$props.mapId}_${$$props.panoId}`;
-      const cachedData = (_a = window.geometaMetaCache) == null ? void 0 : _a.get(cacheKey);
+      const cachedData = (_a2 = window.geometaMetaCache) == null ? void 0 : _a2.get(cacheKey);
       if (cachedData) {
-        set(geoInfo, proxy(cachedData));
+        set(geoInfo, cachedData, true);
       } else {
         const urlParams = new URLSearchParams({
           panoId: $$props.panoId,
@@ -3429,7 +4369,7 @@
             if (response.status === 200) {
               try {
                 const data = JSON.parse(response.responseText);
-                set(geoInfo, proxy(data));
+                set(geoInfo, data, true);
                 if (!window.geometaMetaCache) {
                   window.geometaMetaCache = /* @__PURE__ */ new Map();
                 }
@@ -3469,18 +4409,18 @@
     });
     function confirmNavigation(event2) {
       event2.preventDefault();
-      set(currentUrl, proxy(event2.currentTarget.href));
+      set(currentUrl, event2.currentTarget.href, true);
       set(showModal, true);
     }
-    let showModal = state(false);
-    let currentUrl = state("");
-    let showHelpPopup = state(false);
-    let helpClass = state("question-mark-icon");
+    let showModal = /* @__PURE__ */ state(false);
+    let currentUrl = /* @__PURE__ */ state("");
+    let showHelpPopup = /* @__PURE__ */ state(false);
+    let helpClass = /* @__PURE__ */ state("question-mark-icon");
     function shouldBlink() {
       return !wasHelpMessageRead() || checkIfOutdated();
     }
     function updateHelpClass() {
-      set(helpClass, proxy(shouldBlink() ? "question-mark-icon blink" : "question-mark-icon"));
+      set(helpClass, shouldBlink() ? "question-mark-icon blink" : "question-mark-icon", true);
     }
     updateHelpClass();
     user_effect(() => {
@@ -3492,52 +4432,50 @@
         });
       }
     });
-    let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$3();
-    bind_this(div, ($$value) => container = $$value, () => container);
+    let lastDismissedTimestamp = /* @__PURE__ */ state(proxy(getLastDismissedAnnouncementTimestamp()));
+    var div = root$4();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
       var node_1 = first_child(fragment);
-      if_block(node_1, () => $$props.roundNumber >= 4 && get(announcement) && (!get(lastDismissedTimestamp) || get(announcement).timestamp > get(lastDismissedTimestamp)), ($$anchor3) => {
-        var div_1 = root_2();
-        var div_2 = child(div_1);
-        var node_2 = child(div_2);
-        html(node_2, () => get(announcement).htmlMessage);
-        var button = sibling(div_2, 2);
-        button.__click = [
-          on_click,
-          announcement,
-          lastDismissedTimestamp
-        ];
-        append($$anchor3, div_1);
-      });
+      {
+        var consequent = ($$anchor3) => {
+          var div_1 = root_2();
+          var div_2 = child(div_1);
+          var node_2 = child(div_2);
+          html(node_2, () => get(announcement).htmlMessage);
+          reset(div_2);
+          var button = sibling(div_2, 2);
+          button.__click = [on_click, announcement, lastDismissedTimestamp];
+          reset(div_1);
+          append($$anchor3, div_1);
+        };
+        if_block(node_1, ($$render) => {
+          if ($$props.roundNumber >= 4 && get(announcement) && (!get(lastDismissedTimestamp) || get(announcement).timestamp > get(lastDismissedTimestamp))) $$render(consequent);
+        });
+      }
       append($$anchor2, fragment);
     });
     var div_3 = sibling(node, 2);
-    bind_this(div_3, ($$value) => header = $$value, () => header);
     var div_4 = sibling(child(div_3), 2);
     var a = child(div_4);
     var button_1 = sibling(a, 6);
     button_1.__click = [togglePopup, showHelpPopup, updateHelpClass];
     var span = child(button_1);
+    bind_this(div_3, ($$value) => header = $$value, () => header);
     var node_3 = sibling(div_3, 2);
-    if_block(
-      node_3,
-      () => get(error),
-      ($$anchor2) => {
+    {
+      var consequent_1 = ($$anchor2) => {
         var p = root_3();
         var text = child(p);
         template_effect(() => set_text(text, `Error: ${get(error) ?? ""}`));
         append($$anchor2, p);
-      },
-      ($$anchor2) => {
+      };
+      var alternate_1 = ($$anchor2) => {
         var fragment_1 = comment();
         var node_4 = first_child(fragment_1);
-        if_block(
-          node_4,
-          () => get(geoInfo),
-          ($$anchor3) => {
+        {
+          var consequent_4 = ($$anchor3) => {
             var fragment_2 = root_5();
             var p_1 = first_child(fragment_2);
             var node_5 = child(p_1);
@@ -3553,77 +4491,254 @@
             var node_6 = child(div_5);
             html(node_6, () => get(geoInfo).note);
             var node_7 = sibling(div_5, 2);
-            if_block(node_7, () => get(geoInfo).footer, ($$anchor4) => {
-              var p_2 = root_6();
-              var node_8 = child(p_2);
-              html(node_8, () => get(geoInfo).footer);
-              append($$anchor4, p_2);
-            });
-            var node_9 = sibling(node_7, 2);
-            if_block(node_9, () => get(geoInfo).images && get(geoInfo).images.length, ($$anchor4) => {
-              var fragment_3 = root_7();
-              var node_10 = sibling(first_child(fragment_3), 2);
-              Carousel(node_10, {
-                get images() {
-                  return get(geoInfo).images;
-                }
+            {
+              var consequent_2 = ($$anchor4) => {
+                var p_2 = root_6();
+                var node_8 = child(p_2);
+                html(node_8, () => get(geoInfo).footer);
+                append($$anchor4, p_2);
+              };
+              if_block(node_7, ($$render) => {
+                if (get(geoInfo).footer) $$render(consequent_2);
               });
-              append($$anchor4, fragment_3);
-            });
+            }
+            var node_9 = sibling(node_7, 2);
+            {
+              var consequent_3 = ($$anchor4) => {
+                var fragment_3 = root_7();
+                var node_10 = sibling(first_child(fragment_3), 2);
+                Carousel(node_10, {
+                  get images() {
+                    return get(geoInfo).images;
+                  }
+                });
+                append($$anchor4, fragment_3);
+              };
+              if_block(node_9, ($$render) => {
+                if (get(geoInfo).images && get(geoInfo).images.length) $$render(consequent_3);
+              });
+            }
             template_effect(() => {
               set_text(text_1, get(geoInfo).country);
               set_text(text_2, ` - ${get(geoInfo).metaName ?? ""}`);
             });
             append($$anchor3, fragment_2);
-          },
-          ($$anchor3) => {
+          };
+          var alternate = ($$anchor3) => {
             Spinner($$anchor3);
-          },
-          true
-        );
+          };
+          if_block(
+            node_4,
+            ($$render) => {
+              if (get(geoInfo)) $$render(consequent_4);
+              else $$render(alternate, false);
+            },
+            true
+          );
+        }
         append($$anchor2, fragment_1);
-      }
-    );
-    var node_11 = sibling(node_3, 2);
-    if_block(node_11, () => get(showModal), ($$anchor2) => {
-      var div_6 = root_9();
-      var div_7 = child(div_6);
-      var p_3 = sibling(child(div_7), 2);
-      var text_3 = child(p_3);
-      var div_8 = sibling(p_3, 2);
-      var button_2 = child(div_8);
-      button_2.__click = [proceed, showModal, currentUrl];
-      var button_3 = sibling(button_2, 2);
-      button_3.__click = [cancel, showModal];
-      template_effect(() => set_text(text_3, get(currentUrl)));
-      append($$anchor2, div_6);
-    });
-    var node_12 = sibling(node_11, 2);
-    if_block(node_12, () => get(showHelpPopup), ($$anchor2) => {
-      var div_9 = root_10();
-      var div_10 = child(div_9);
-      var div_11 = child(div_10);
-      var node_13 = child(div_11);
-      if_block(node_13, checkIfOutdated, ($$anchor3) => {
-        var p_4 = root_11();
-        var strong_1 = child(p_4);
-        var text_4 = child(strong_1);
-        template_effect(() => set_text(text_4, `Your script version is out of date - please install the latest
-              version (${getLatestVersionInfo() ?? ""})!`));
-        append($$anchor3, p_4);
+      };
+      if_block(node_3, ($$render) => {
+        if (get(error)) $$render(consequent_1);
+        else $$render(alternate_1, false);
       });
-      var button_4 = sibling(div_11, 2);
-      button_4.__click = [togglePopup, showHelpPopup, updateHelpClass];
-      append($$anchor2, div_9);
-    });
+    }
+    var node_11 = sibling(node_3, 2);
+    {
+      var consequent_5 = ($$anchor2) => {
+        var div_6 = root_9();
+        var div_7 = child(div_6);
+        var p_3 = sibling(child(div_7), 2);
+        var text_3 = child(p_3);
+        var div_8 = sibling(p_3, 2);
+        var button_2 = child(div_8);
+        button_2.__click = [proceed, showModal, currentUrl];
+        var button_3 = sibling(button_2, 2);
+        button_3.__click = [cancel, showModal];
+        template_effect(() => set_text(text_3, get(currentUrl)));
+        append($$anchor2, div_6);
+      };
+      if_block(node_11, ($$render) => {
+        if (get(showModal)) $$render(consequent_5);
+      });
+    }
+    var node_12 = sibling(node_11, 2);
+    {
+      var consequent_7 = ($$anchor2) => {
+        var div_9 = root_10();
+        var div_10 = child(div_9);
+        var div_11 = child(div_10);
+        var node_13 = child(div_11);
+        {
+          var consequent_6 = ($$anchor3) => {
+            var p_4 = root_11();
+            var strong_1 = child(p_4);
+            var text_4 = child(strong_1);
+            template_effect(
+              ($0) => set_text(text_4, `Your script version is out of date - please install the latest
+              version (${$0 ?? ""})!`),
+              [getLatestVersionInfo]
+            );
+            append($$anchor3, p_4);
+          };
+          if_block(node_13, ($$render) => {
+            if (checkIfOutdated()) $$render(consequent_6);
+          });
+        }
+        var button_4 = sibling(div_11, 2);
+        button_4.__click = [togglePopup, showHelpPopup, updateHelpClass];
+        append($$anchor2, div_9);
+      };
+      if_block(node_12, ($$render) => {
+        if (get(showHelpPopup)) $$render(consequent_7);
+      });
+    }
+    bind_this(div, ($$value) => container = $$value, () => container);
     template_effect(() => {
       set_attribute(a, "href", "https://learnablemeta.com/maps/" + $$props.mapId);
-      set_class(span, `${get(helpClass) ?? ""} svelte-a3mhc8`);
+      set_class(span, 1, clsx(get(helpClass)), "svelte-a3mhc8");
     });
     append($$anchor, div);
     pop();
   }
   delegate(["click"]);
+  var root_1$1 = /* @__PURE__ */ from_html(`<div class="error svelte-rfbclr"> </div>`);
+  var root$3 = /* @__PURE__ */ from_html(`<div class="hint-panel svelte-rfbclr"><header class="svelte-rfbclr"><strong>Hint</strong> <button class="close svelte-rfbclr">×</button></header> <div><label>Country <input class="svelte-rfbclr"/></label></div> <div><label>Meta type <input class="svelte-rfbclr"/></label></div> <div><label>Description <textarea rows="2" class="svelte-rfbclr"></textarea></label></div> <!> <button>Submit</button></div>`);
+  function HintPanel($$anchor, $$props) {
+    push($$props, false);
+    const SUPABASE_URL = "https://kacuunztbvznzhfsyfgp.supabase.co";
+    const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImthY3V1bnp0YnZ6bnpoZnN5ZmdwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQxODY0NjEsImV4cCI6MjA2OTc2MjQ2MX0.VsC1HLOG413lXABUn4Sfv9c_arN06IxH9EXIdn-fzj4";
+    let country = /* @__PURE__ */ mutable_source("");
+    let meta_type = /* @__PURE__ */ mutable_source("");
+    let description = /* @__PURE__ */ mutable_source("");
+    let image_url = "";
+    let error = /* @__PURE__ */ mutable_source("");
+    const metaTypes = [
+      "bollard",
+      "car",
+      "sign",
+      "language",
+      "generation",
+      "antenna",
+      "coverage"
+    ];
+    onMount(() => {
+      detectCountry();
+      detectMetaType();
+      detectImage();
+    });
+    function detectCountry() {
+      var _a2;
+      const flag = document.querySelector('[class*="result-layout_flag"] img, img.flag');
+      const alt = (_a2 = flag == null ? void 0 : flag.getAttribute("alt")) == null ? void 0 : _a2.trim();
+      if (alt) {
+        set(country, alt);
+      }
+    }
+    function detectMetaType() {
+      var _a2, _b;
+      const note = ((_b = (_a2 = document.querySelector(".geometa-note")) == null ? void 0 : _a2.textContent) == null ? void 0 : _b.toLowerCase()) || "";
+      const found = metaTypes.find((t) => note.includes(t));
+      if (found) {
+        set(meta_type, found);
+      }
+    }
+    function detectImage() {
+      const img = document.querySelector('[class*="result-layout_root"] img.responsive-image');
+      image_url = (img == null ? void 0 : img.getAttribute("src")) || "";
+    }
+    function gmRequest(options) {
+      return new Promise((resolve, reject) => {
+        _GM_xmlhttpRequest({ ...options, onload: resolve, onerror: reject });
+      });
+    }
+    async function submit() {
+      try {
+        detectImage();
+        const res = await gmRequest({
+          method: "POST",
+          url: `${SUPABASE_URL}/rest/v1/hints`,
+          headers: {
+            apikey: SUPABASE_KEY,
+            Authorization: `Bearer ${SUPABASE_KEY}`,
+            "Content-Type": "application/json"
+          },
+          data: JSON.stringify({
+            country: get(country),
+            meta_type: get(meta_type),
+            description: get(description),
+            image_url
+          })
+        });
+        if (res.status >= 200 && res.status < 300) {
+          set(country, "");
+          set(meta_type, "");
+          set(description, "");
+          image_url = "";
+          set(error, "");
+        } else {
+          set(error, "Failed to submit");
+        }
+      } catch (e) {
+        set(error, "Failed to submit");
+      }
+    }
+    init();
+    var div = root$3();
+    var header = child(div);
+    var button = sibling(child(header), 2);
+    var div_1 = sibling(header, 2);
+    var label = child(div_1);
+    var input = sibling(child(label));
+    var div_2 = sibling(div_1, 2);
+    var label_1 = child(div_2);
+    var input_1 = sibling(child(label_1));
+    var div_3 = sibling(div_2, 2);
+    var label_2 = child(div_3);
+    var textarea = sibling(child(label_2));
+    var node = sibling(div_3, 2);
+    {
+      var consequent = ($$anchor2) => {
+        var div_4 = root_1$1();
+        var text = child(div_4);
+        template_effect(() => set_text(text, get(error)));
+        append($$anchor2, div_4);
+      };
+      if_block(node, ($$render) => {
+        if (get(error)) $$render(consequent);
+      });
+    }
+    var button_1 = sibling(node, 2);
+    event("click", button, () => {
+      var _a2;
+      return (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
+    });
+    bind_value(input, () => get(country), ($$value) => set(country, $$value));
+    event("keydown", input, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    bind_value(input_1, () => get(meta_type), ($$value) => set(meta_type, $$value));
+    event("keydown", input_1, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    bind_value(textarea, () => get(description), ($$value) => set(description, $$value));
+    event("keydown", textarea, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    event("click", button_1, submit);
+    append($$anchor, div);
+    pop();
+  }
+  function mountHintPanel(container) {
+    const existing = document.getElementById("geometa-hints");
+    if (existing) {
+      existing.remove();
+    }
+    const element = document.createElement("div");
+    element.id = "geometa-hints";
+    container.appendChild(element);
+    mount(HintPanel, { target: element });
+  }
   const GeoGuessrEventFramework = _unsafeWindow.GeoGuessrEventFramework;
   let currentObserver = null;
   let currentPinObserver = null;
@@ -3639,15 +4754,16 @@
         await getMapInfo(event2.detail.map.id, true);
       });
       GeoGuessrEventFramework.events.addEventListener("round_end", async (event2) => {
-        var _a;
-        (_a = document.getElementById("geometa-summary")) == null ? void 0 : _a.remove();
+        var _a2, _b;
+        (_a2 = document.getElementById("geometa-summary")) == null ? void 0 : _a2.remove();
+        (_b = document.getElementById("geometa-hints")) == null ? void 0 : _b.remove();
         const mapInfo = await getMapInfo(event2.detail.map.id, false);
         if (!mapInfo.mapFound) {
           logInfo("not supported map - skip");
           return;
         }
         logInfo("waiting for the result view to render");
-        waitForElement('div[data-qa="result-view-top"]').then((container) => {
+        waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
           if (!container) {
             return;
           }
@@ -3667,6 +4783,7 @@
               source: window.location.href.includes("challenge") ? "challenge" : "map"
             }
           });
+          mountHintPanel(container);
         });
       });
       GeoGuessrEventFramework.events.addEventListener("game_end", async (event2) => {
@@ -3701,6 +4818,7 @@
         addClickableIconsToPins(roundData.rounds, roundData.mapId, roundData.userscriptVersion);
       });
       window.addEventListener("urlchange", () => {
+        var _a2;
         clearMetaCache();
         if (currentObserver) {
           currentObserver.disconnect();
@@ -3710,16 +4828,17 @@
           currentPinObserver.disconnect();
           currentPinObserver = null;
         }
+        (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
       });
     });
   }
   function addMetaButtonsToRounds(rounds, mapId, userscriptVersion) {
     const roundItems = document.querySelectorAll(".result-list_listItemWrapper___XCGn");
     rounds.forEach((round, index2) => {
-      var _a;
+      var _a2;
       const roundItem = roundItems[index2];
       if (!roundItem) return;
-      const roundNumber = (_a = roundItem.querySelector(".result-list_roundNumber__RlIKm")) == null ? void 0 : _a.textContent;
+      const roundNumber = (_a2 = roundItem.querySelector(".result-list_roundNumber__RlIKm")) == null ? void 0 : _a2.textContent;
       if (roundNumber === "Total") return;
       if (roundItem.querySelector(".geometa-meta-btn")) return;
       const metaButton = document.createElement("button");
@@ -3762,8 +4881,8 @@
     currentPinObserver = new MutationObserver(() => {
       const pins = document.querySelectorAll('[class*="map-pin_mapPin"]');
       pins.forEach((pin) => {
-        var _a;
-        const pinText = (_a = pin.textContent) == null ? void 0 : _a.trim();
+        var _a2;
+        const pinText = (_a2 = pin.textContent) == null ? void 0 : _a2.trim();
         const roundNumber = parseInt(pinText || "");
         if (roundNumber >= 1 && roundNumber <= 5 && !pin.hasAttribute("data-geometa-pin-processed")) {
           pin.setAttribute("data-geometa-pin-processed", "true");
@@ -3796,7 +4915,8 @@
   function initLiveChallenge() {
     logInfo("live challenge support enabled");
     let pinChanged = false;
-    const observer = new MutationObserver(async (mutations) => {
+    const observer = new MutationObserver(async () => {
+      var _a2;
       if (!document.querySelector("[class*=result-map_roundPin]")) {
         pinChanged = false;
         return;
@@ -3805,12 +4925,13 @@
         return;
       }
       pinChanged = true;
+      (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
       const challengeId = getChallengeId();
       if (challengeId) {
         const { mapId, panoId } = await getChallengeInfo(challengeId);
         const mapInfo = await getMapInfo(mapId, false);
         if (!mapInfo.mapFound) return;
-        waitForElement("[class*=game_container]").then((container) => {
+        waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
           if (!container) {
             return;
           }
@@ -3828,6 +4949,7 @@
               source: "liveChallenge"
             }
           });
+          mountHintPanel(container);
         });
       }
     });
@@ -3836,6 +4958,11 @@
     } else {
       console.error("document.body is not available.");
     }
+    window.addEventListener("urlchange", () => {
+      var _a2;
+      observer.disconnect();
+      (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
+    });
   }
   function initURLChangeEvent() {
     overrideHistoryMethod("pushState");
@@ -3852,7 +4979,7 @@
       return result;
     };
   }
-  var root$2 = /* @__PURE__ */ template(`<div class="geometa-map-label-container svelte-1mmcvqu"><p class="svelte-1mmcvqu">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1mmcvqu">Meta List</button></a></div>`);
+  var root$2 = /* @__PURE__ */ from_html(`<div class="geometa-map-label-container svelte-1mmcvqu"><p class="svelte-1mmcvqu">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1mmcvqu">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
     var div = root$2();
     var a = sibling(child(div), 2);
@@ -4052,23 +5179,25 @@
       css: (t) => `opacity: ${t * o}`
     };
   }
-  var root$1 = /* @__PURE__ */ template(`<div role="alert"><span class="toast-message svelte-1rq8lsd"> </span> <button class="toast-close-button svelte-1rq8lsd" aria-label="Close">×</button></div>`);
+  var root$1 = /* @__PURE__ */ from_html(`<div role="alert"><span class="toast-message svelte-1rq8lsd"> </span> <button class="toast-close-button svelte-1rq8lsd" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
     var div = root$1();
+    set_style(div, "", {}, {
+      position: "absolute",
+      top: "100%",
+      transform: "translateX(-75%) translateY(-10px)",
+      "margin-top": "10px"
+    });
     var span = child(div);
     var text = child(span);
     var button = sibling(span, 2);
     button.__click = function(...$$args) {
-      var _a;
-      (_a = $$props.onClose) == null ? void 0 : _a.apply(this, $$args);
+      var _a2;
+      (_a2 = $$props.onClose) == null ? void 0 : _a2.apply(this, $$args);
     };
     template_effect(() => {
-      set_class(div, `toast-notification toast-${type() ?? ""} svelte-1rq8lsd`);
-      set_style(div, "position", "absolute");
-      set_style(div, "top", "100%");
-      set_style(div, "transform", "translateX(-75%) translateY(-10px)");
-      set_style(div, "margin-top", "10px");
+      set_class(div, 1, `toast-notification toast-${type() ?? ""}`, "svelte-1rq8lsd");
       set_text(text, $$props.message);
     });
     transition(1, div, () => fade, () => ({ duration: 200, delay: 50 }));
@@ -4078,7 +5207,7 @@
   delegate(["click"]);
   async function handleUploadClick(_, isLoading, currentApiKey, getApiKeyFromGM, apiKeyInput, showApiKeyModal, performUpload) {
     if (get(isLoading)) return;
-    set(currentApiKey, proxy(getApiKeyFromGM()));
+    set(currentApiKey, getApiKeyFromGM(), true);
     if (!get(currentApiKey) || get(currentApiKey).trim() === "") {
       set(apiKeyInput, "");
       set(showApiKeyModal, true);
@@ -4090,7 +5219,7 @@
     const trimmedKey = get(apiKeyInput).trim();
     if (trimmedKey) {
       saveApiKeyToGM(trimmedKey);
-      set(currentApiKey, proxy(trimmedKey));
+      set(currentApiKey, trimmedKey, true);
       set(showApiKeyModal, false);
       showCustomToast("API Key saved!", "success", 2e3);
       performUpload(trimmedKey);
@@ -4102,30 +5231,34 @@
     set(showApiKeyModal, false);
     set(apiKeyInput, "");
   }
-  var root_1 = /* @__PURE__ */ template(`<div class="modal-overlay svelte-17or0cf" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-17or0cf"><h2 id="apiKeyModalTitle" class="svelte-17or0cf">Enter LearnableMeta API Key</h2> <p class="svelte-17or0cf">An API key is required to upload locations. Please paste your key below.</p> <p class="svelte-17or0cf">You can generate your API token by visiting <a target="_blank" rel="noopener noreferrer" class="svelte-17or0cf">profile page</a> on LearnableMeta and generating it there.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-17or0cf"> <div class="modal-actions svelte-17or0cf"><button class="modal-button modal-button-save svelte-17or0cf">Save & Upload</button> <button class="modal-button modal-button-cancel svelte-17or0cf">Cancel</button></div> <p class="modal-note svelte-17or0cf">Your API key will be stored securely in your browser's userscript storage for future
+  var root_1 = /* @__PURE__ */ from_html(`<div class="modal-overlay svelte-17or0cf" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-17or0cf"><h2 id="apiKeyModalTitle" class="svelte-17or0cf">Enter LearnableMeta API Key</h2> <p class="svelte-17or0cf">An API key is required to upload locations. Please paste your key below.</p> <p class="svelte-17or0cf">You can generate your API token by visiting <a target="_blank" rel="noopener noreferrer" class="svelte-17or0cf">profile page</a> on LearnableMeta and generating it there.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-17or0cf"/> <div class="modal-actions svelte-17or0cf"><button class="modal-button modal-button-save svelte-17or0cf">Save & Upload</button> <button class="modal-button modal-button-cancel svelte-17or0cf">Cancel</button></div> <p class="modal-note svelte-17or0cf">Your API key will be stored securely in your browser's userscript storage for future
         use.</p></div></div>`);
-  var root = /* @__PURE__ */ template(`<div class="upload-label-container"><button class="button_button__aR6_e button_sizeSmall__MB_qj custom-yellow-button svelte-17or0cf"> </button></div> <!> <!>`, 1);
+  var root = /* @__PURE__ */ from_html(`<div class="upload-label-container"><button class="button_button__aR6_e button_sizeSmall__MB_qj custom-yellow-button svelte-17or0cf"> </button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
     const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
-    let showApiKeyModal = state(false);
-    let apiKeyInput = state("");
-    let currentApiKey = state(null);
-    let isLoading = state(false);
-    let toastState = state(null);
-    let toastTimer = state(void 0);
+    let showApiKeyModal = /* @__PURE__ */ state(false);
+    let apiKeyInput = /* @__PURE__ */ state("");
+    let currentApiKey = /* @__PURE__ */ state(null);
+    let isLoading = /* @__PURE__ */ state(false);
+    let toastState = /* @__PURE__ */ state(null);
+    let toastTimer = /* @__PURE__ */ state(void 0);
     function showCustomToast(message, type = "info", duration = 3e3) {
       clearTimeout(get(toastTimer));
       const displayToast = () => {
-        set(toastState, proxy({ message, type }));
+        set(toastState, { message, type }, true);
         if (duration > 0) {
-          set(toastTimer, proxy(setTimeout(
-            () => {
-              hideCustomToast();
-            },
-            duration
-          )));
+          set(
+            toastTimer,
+            setTimeout(
+              () => {
+                hideCustomToast();
+              },
+              duration
+            ),
+            true
+          );
         }
       };
       if (get(toastState)) {
@@ -4157,14 +5290,14 @@
       }
     }
     onMount(() => {
-      set(currentApiKey, proxy(getApiKeyFromGM()));
+      set(currentApiKey, getApiKeyFromGM(), true);
       if (typeof _GM_registerMenuCommand === "function") {
         _GM_registerMenuCommand("LearnableMeta - Set/Update API Key", () => {
           set(currentApiKey, null);
           const newKey = prompt("Enter your new LearnableMeta API Key:");
           if (newKey && newKey.trim() !== "") {
             saveApiKeyToGM(newKey.trim());
-            set(currentApiKey, proxy(newKey.trim()));
+            set(currentApiKey, newKey.trim(), true);
             showCustomToast("LearnableMeta API Key updated!", "success");
           } else if (newKey !== null) {
             showCustomToast("API Key not updated (empty value provided).", "info");
@@ -4218,45 +5351,51 @@
     ];
     var text = child(button);
     var node = sibling(div, 2);
-    if_block(node, () => get(showApiKeyModal), ($$anchor2) => {
-      var div_1 = root_1();
-      var div_2 = child(div_1);
-      var p = sibling(child(div_2), 4);
-      var a = sibling(child(p));
-      set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
-      var input = sibling(p, 2);
-      var div_3 = sibling(input, 2);
-      var button_1 = child(div_3);
-      button_1.__click = [
-        handleSaveApiKey,
-        apiKeyInput,
-        saveApiKeyToGM,
-        currentApiKey,
-        showApiKeyModal,
-        showCustomToast,
-        performUpload
-      ];
-      var button_2 = sibling(button_1, 2);
-      button_2.__click = [
-        handleCancelModal,
-        showApiKeyModal,
-        apiKeyInput
-      ];
-      bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
-      append($$anchor2, div_1);
-    });
-    var node_1 = sibling(node, 2);
-    if_block(node_1, () => get(toastState), ($$anchor2) => {
-      ToastNotification($$anchor2, {
-        get message() {
-          return get(toastState).message;
-        },
-        get type() {
-          return get(toastState).type;
-        },
-        onClose: hideCustomToast
+    {
+      var consequent = ($$anchor2) => {
+        var div_1 = root_1();
+        var div_2 = child(div_1);
+        var p = sibling(child(div_2), 4);
+        var a = sibling(child(p));
+        set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
+        var input = sibling(p, 2);
+        var div_3 = sibling(input, 2);
+        var button_1 = child(div_3);
+        button_1.__click = [
+          handleSaveApiKey,
+          apiKeyInput,
+          saveApiKeyToGM,
+          currentApiKey,
+          showApiKeyModal,
+          showCustomToast,
+          performUpload
+        ];
+        var button_2 = sibling(button_1, 2);
+        button_2.__click = [handleCancelModal, showApiKeyModal, apiKeyInput];
+        bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
+        append($$anchor2, div_1);
+      };
+      if_block(node, ($$render) => {
+        if (get(showApiKeyModal)) $$render(consequent);
       });
-    });
+    }
+    var node_1 = sibling(node, 2);
+    {
+      var consequent_1 = ($$anchor2) => {
+        ToastNotification($$anchor2, {
+          get message() {
+            return get(toastState).message;
+          },
+          get type() {
+            return get(toastState).type;
+          },
+          onClose: hideCustomToast
+        });
+      };
+      if_block(node_1, ($$render) => {
+        if (get(toastState)) $$render(consequent_1);
+      });
+    }
     template_effect(() => {
       button.disabled = get(isLoading);
       set_text(text, get(isLoading) ? "Uploading..." : "LearnableMeta - Upload");
@@ -4277,12 +5416,12 @@
   }
   const containerId = "geometa-locations-upload";
   async function addLocationsUploadButtons() {
-    var _a;
+    var _a2;
     const mapId = extractMapIdFromMapMakerUrl(window.location.href);
     if (!mapId) {
       return;
     }
-    (_a = document.getElementById(containerId)) == null ? void 0 : _a.remove();
+    (_a2 = document.getElementById(containerId)) == null ? void 0 : _a2.remove();
     const mapInfo = await getMapInfo(mapId, true);
     if (!(mapInfo == null ? void 0 : mapInfo.mapFound)) {
       return;

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -10,6 +10,7 @@
 // @match        *://*.geoguessr.com/*
 // @require      https://raw.githubusercontent.com/miraclewhips/geoguessr-event-framework/5e449d6b64c828fce5d2915772d61c7f95263e34/geoguessr-event-framework.js
 // @connect      learnablemeta.com
+// @connect      kacuunztbvznzhfsyfgp.supabase.co
 // @grant        GM_addStyle
 // @grant        GM_getValue
 // @grant        GM_info
@@ -20,11 +21,23 @@
 // @run-at       document-start
 // ==/UserScript==
 
-(e=>{if(typeof GM_addStyle=="function"){GM_addStyle(e);return}const o=document.createElement("style");o.textContent=e,document.head.append(o)})(` .loadership_ZOJAQ.svelte-i1jlc0{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-i1jlc0-loadership_ZOJAQ_scale 1.2s infinite,svelte-i1jlc0-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-i1jlc0-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-i1jlc0-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-7lhsry{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-fofh7f{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-fofh7f{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-fofh7f{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-fofh7f{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-fofh7f{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-fofh7f{left:0}.next-area.svelte-fofh7f{right:0}.prev.svelte-fofh7f,.next.svelte-fofh7f{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-fofh7f{left:0}.next.svelte-fofh7f{right:0}.indicators.svelte-fofh7f{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-fofh7f{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-fofh7f{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-a3mhc8{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100);padding:6px 10px;border-radius:5px;font-size:17px;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-a3mhc8>.header:where(.svelte-a3mhc8){margin-top:0}.geometa-footer.svelte-a3mhc8{color:#d3d3d3;font-size:small}.announcement.svelte-a3mhc8{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-a3mhc8{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-a3mhc8:hover,.vote-close-btn.svelte-a3mhc8:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-a3mhc8{color:#188bd2}a.svelte-a3mhc8:hover{text-decoration:underline}.skill-icons--discord.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-a3mhc8{display:inline-block;vertical-align:middle}.flex.svelte-a3mhc8{display:flex;align-items:center}.icons.svelte-a3mhc8 a:where(.svelte-a3mhc8) span:where(.svelte-a3mhc8){align-items:center;justify-content:center}hr.svelte-a3mhc8{border:0;border-top:1px solid white;width:100%}.header.svelte-a3mhc8{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-a3mhc8{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-a3mhc8{background:var(--ds-color-purple-100);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-a3mhc8 p:where(.svelte-a3mhc8){margin:0 0 10px;font-size:17px}.modal-url.svelte-a3mhc8{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-a3mhc8{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-a3mhc8{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-a3mhc8:hover{background:#0056b3}.close-btn.svelte-a3mhc8{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-a3mhc8:hover{background:#d3d3d3;color:var(--ds-color-purple-100)}button.svelte-a3mhc8{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-a3mhc8{animation:svelte-a3mhc8-blink-animation 1s infinite}.help-message.svelte-a3mhc8{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:#007bff;font-weight:700}@keyframes svelte-a3mhc8-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1mmcvqu{background-color:#0003;color:#fff;text-align:center;z-index:999999;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px;text-shadow:0 0 10px rgba(255,255,255,.1)}p.svelte-1mmcvqu{font-size:14px;font-weight:700}button.svelte-1mmcvqu{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-1rq8lsd{z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-1rq8lsd{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-1rq8lsd{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-1rq8lsd{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-1rq8lsd{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-message.svelte-1rq8lsd{flex-grow:1;margin-right:10px}.toast-close-button.svelte-1rq8lsd{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-1rq8lsd:hover{opacity:1}.custom-yellow-button.svelte-17or0cf{background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-17or0cf:hover:not(:where(.svelte-17or0cf):disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-17or0cf:active:not(:where(.svelte-17or0cf):disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-17or0cf:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-17or0cf:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.modal-overlay.svelte-17or0cf{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-17or0cf{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-17or0cf h2:where(.svelte-17or0cf){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf){margin-bottom:15px;line-height:1.6}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf){color:#007bff;text-decoration:underline}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf):hover{color:#0056b3}.modal-input.svelte-17or0cf{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-17or0cf{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-17or0cf{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-17or0cf{background-color:#28a745;color:#fff}.modal-button-save.svelte-17or0cf:hover{background-color:#218838}.modal-button-cancel.svelte-17or0cf{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-17or0cf:hover{background-color:#5a6268}.modal-note.svelte-17or0cf{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
+(e=>{if(typeof GM_addStyle=="function"){GM_addStyle(e);return}const o=document.createElement("style");o.textContent=e,document.head.append(o)})(` .loadership_ZOJAQ.svelte-i1jlc0{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-i1jlc0-loadership_ZOJAQ_scale 1.2s infinite,svelte-i1jlc0-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-i1jlc0 div:where(.svelte-i1jlc0):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-i1jlc0-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-i1jlc0-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-7lhsry{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-fofh7f{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-fofh7f{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-fofh7f{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-fofh7f{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-fofh7f{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-fofh7f{left:0}.next-area.svelte-fofh7f{right:0}.prev.svelte-fofh7f,.next.svelte-fofh7f{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-fofh7f{left:0}.next.svelte-fofh7f{right:0}.indicators.svelte-fofh7f{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-fofh7f{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-fofh7f{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-a3mhc8{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100);padding:6px 10px;border-radius:5px;font-size:17px;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-a3mhc8>.header:where(.svelte-a3mhc8){margin-top:0}.geometa-footer.svelte-a3mhc8{color:#d3d3d3;font-size:small}.announcement.svelte-a3mhc8{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-a3mhc8{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-a3mhc8:hover,.vote-close-btn.svelte-a3mhc8:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-a3mhc8{color:#188bd2}a.svelte-a3mhc8:hover{text-decoration:underline}.skill-icons--discord.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-a3mhc8{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-a3mhc8{display:inline-block;vertical-align:middle}.flex.svelte-a3mhc8{display:flex;align-items:center}.icons.svelte-a3mhc8 a:where(.svelte-a3mhc8) span:where(.svelte-a3mhc8){align-items:center;justify-content:center}hr.svelte-a3mhc8{border:0;border-top:1px solid white;width:100%}.header.svelte-a3mhc8{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-a3mhc8{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-a3mhc8{background:var(--ds-color-purple-100);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-a3mhc8 p:where(.svelte-a3mhc8){margin:0 0 10px;font-size:17px}.modal-url.svelte-a3mhc8{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-a3mhc8{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-a3mhc8{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-a3mhc8:hover{background:#0056b3}.close-btn.svelte-a3mhc8{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-a3mhc8:hover{background:#d3d3d3;color:var(--ds-color-purple-100)}button.svelte-a3mhc8{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-a3mhc8{animation:svelte-a3mhc8-blink-animation 1s infinite}.help-message.svelte-a3mhc8{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:#007bff;font-weight:700}@keyframes svelte-a3mhc8-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-a3mhc8 strong:where(.svelte-a3mhc8){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.hint-panel.svelte-rfbclr{position:fixed;bottom:1rem;right:1rem;background:#444;color:#fff;padding:.5rem;border:1px solid #ccc;border-radius:4px;z-index:9999;box-shadow:0 2px 6px #0003;max-width:300px}.hint-panel.svelte-rfbclr input:where(.svelte-rfbclr),.hint-panel.svelte-rfbclr textarea:where(.svelte-rfbclr){width:100%;margin-bottom:.25rem;color:#000;background:#fff}.hint-panel.svelte-rfbclr .error:where(.svelte-rfbclr){color:#f88;font-size:.8rem;margin-bottom:.25rem}.hint-panel.svelte-rfbclr header:where(.svelte-rfbclr){display:flex;justify-content:space-between;align-items:center;margin-bottom:.25rem}.hint-panel.svelte-rfbclr button.close:where(.svelte-rfbclr){background:transparent;border:none;cursor:pointer;color:#fff}.geometa-map-label-container.svelte-1mmcvqu{background-color:#0003;color:#fff;text-align:center;z-index:999999;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px;text-shadow:0 0 10px rgba(255,255,255,.1)}p.svelte-1mmcvqu{font-size:14px;font-weight:700}button.svelte-1mmcvqu{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-1rq8lsd{z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-1rq8lsd{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-1rq8lsd{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-1rq8lsd{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-1rq8lsd{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-message.svelte-1rq8lsd{flex-grow:1;margin-right:10px}.toast-close-button.svelte-1rq8lsd{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-1rq8lsd:hover{opacity:1}.custom-yellow-button.svelte-17or0cf{background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-17or0cf:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-17or0cf:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-17or0cf:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-17or0cf:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.modal-overlay.svelte-17or0cf{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-17or0cf{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-17or0cf h2:where(.svelte-17or0cf){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf){margin-bottom:15px;line-height:1.6}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf){color:#007bff;text-decoration:underline}.modal-content.svelte-17or0cf p:where(.svelte-17or0cf) a:where(.svelte-17or0cf):hover{color:#0056b3}.modal-input.svelte-17or0cf{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-17or0cf{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-17or0cf{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-17or0cf{background-color:#28a745;color:#fff}.modal-button-save.svelte-17or0cf:hover{background-color:#218838}.modal-button-cancel.svelte-17or0cf{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-17or0cf:hover{background-color:#5a6268}.modal-note.svelte-17or0cf{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
 
 (async function () {
   'use strict';
 
+  var __defProp = Object.defineProperty;
+  var __typeError = (msg) => {
+    throw TypeError(msg);
+  };
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  var __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg);
+  var __privateGet = (obj, member, getter) => (__accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj));
+  var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+  var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), member.set(obj, value), value);
+  var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
+  var _current, _previous, _callbacks, _pending, _deferred, _neutered, _async_effects, _boundary_async_effects, _render_effects, _effects, _block_effects, _Batch_instances, process_fn, traverse_effect_tree_fn, commit_fn, _a;
   var _GM_getValue = /* @__PURE__ */ (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = /* @__PURE__ */ (() => typeof GM_info != "undefined" ? GM_info : void 0)();
   var _GM_registerMenuCommand = /* @__PURE__ */ (() => typeof GM_registerMenuCommand != "undefined" ? GM_registerMenuCommand : void 0)();
@@ -177,6 +190,7 @@
   }
   const DEV = false;
   var is_array = Array.isArray;
+  var index_of = Array.prototype.indexOf;
   var array_from = Array.from;
   var define_property = Object.defineProperty;
   var get_descriptor = Object.getOwnPropertyDescriptor;
@@ -184,6 +198,7 @@
   var object_prototype = Object.prototype;
   var array_prototype = Array.prototype;
   var get_prototype_of = Object.getPrototypeOf;
+  var is_extensible = Object.isExtensible;
   function is_function(thing) {
     return typeof thing === "function";
   }
@@ -200,26 +215,124 @@
       arr[i]();
     }
   }
+  function deferred() {
+    var resolve;
+    var reject;
+    var promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
   const DERIVED = 1 << 1;
   const EFFECT = 1 << 2;
   const RENDER_EFFECT = 1 << 3;
   const BLOCK_EFFECT = 1 << 4;
   const BRANCH_EFFECT = 1 << 5;
   const ROOT_EFFECT = 1 << 6;
-  const UNOWNED = 1 << 7;
-  const DISCONNECTED = 1 << 8;
-  const CLEAN = 1 << 9;
-  const DIRTY = 1 << 10;
-  const MAYBE_DIRTY = 1 << 11;
-  const INERT = 1 << 12;
-  const DESTROYED = 1 << 13;
-  const EFFECT_RAN = 1 << 14;
-  const EFFECT_TRANSPARENT = 1 << 15;
-  const LEGACY_DERIVED_PROP = 1 << 16;
+  const BOUNDARY_EFFECT = 1 << 7;
+  const UNOWNED = 1 << 8;
+  const DISCONNECTED = 1 << 9;
+  const CLEAN = 1 << 10;
+  const DIRTY = 1 << 11;
+  const MAYBE_DIRTY = 1 << 12;
+  const INERT = 1 << 13;
+  const DESTROYED = 1 << 14;
+  const EFFECT_RAN = 1 << 15;
+  const EFFECT_TRANSPARENT = 1 << 16;
+  const INSPECT_EFFECT = 1 << 17;
   const HEAD_EFFECT = 1 << 18;
-  const EFFECT_HAS_DERIVED = 1 << 19;
+  const EFFECT_PRESERVED = 1 << 19;
+  const USER_EFFECT = 1 << 20;
+  const REACTION_IS_UPDATING = 1 << 21;
+  const ASYNC = 1 << 22;
+  const ERROR_VALUE = 1 << 23;
   const STATE_SYMBOL = Symbol("$state");
+  const LEGACY_PROPS = Symbol("legacy props");
   const LOADING_ATTR_SYMBOL = Symbol("");
+  const STALE_REACTION = new class StaleReactionError extends Error {
+    constructor() {
+      super(...arguments);
+      __publicField(this, "name", "StaleReactionError");
+      __publicField(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
+    }
+  }();
+  function await_outside_boundary() {
+    {
+      throw new Error(`https://svelte.dev/e/await_outside_boundary`);
+    }
+  }
+  function lifecycle_outside_component(name) {
+    {
+      throw new Error(`https://svelte.dev/e/lifecycle_outside_component`);
+    }
+  }
+  function async_derived_orphan() {
+    {
+      throw new Error(`https://svelte.dev/e/async_derived_orphan`);
+    }
+  }
+  function effect_in_teardown(rune) {
+    {
+      throw new Error(`https://svelte.dev/e/effect_in_teardown`);
+    }
+  }
+  function effect_in_unowned_derived() {
+    {
+      throw new Error(`https://svelte.dev/e/effect_in_unowned_derived`);
+    }
+  }
+  function effect_orphan(rune) {
+    {
+      throw new Error(`https://svelte.dev/e/effect_orphan`);
+    }
+  }
+  function effect_update_depth_exceeded() {
+    {
+      throw new Error(`https://svelte.dev/e/effect_update_depth_exceeded`);
+    }
+  }
+  function props_invalid_value(key) {
+    {
+      throw new Error(`https://svelte.dev/e/props_invalid_value`);
+    }
+  }
+  function state_descriptors_fixed() {
+    {
+      throw new Error(`https://svelte.dev/e/state_descriptors_fixed`);
+    }
+  }
+  function state_prototype_fixed() {
+    {
+      throw new Error(`https://svelte.dev/e/state_prototype_fixed`);
+    }
+  }
+  function state_unsafe_mutation() {
+    {
+      throw new Error(`https://svelte.dev/e/state_unsafe_mutation`);
+    }
+  }
+  const EACH_ITEM_REACTIVE = 1;
+  const EACH_INDEX_REACTIVE = 1 << 1;
+  const EACH_IS_CONTROLLED = 1 << 2;
+  const EACH_IS_ANIMATED = 1 << 3;
+  const EACH_ITEM_IMMUTABLE = 1 << 4;
+  const PROPS_IS_IMMUTABLE = 1;
+  const PROPS_IS_RUNES = 1 << 1;
+  const PROPS_IS_UPDATED = 1 << 2;
+  const PROPS_IS_BINDABLE = 1 << 3;
+  const PROPS_IS_LAZY_INITIAL = 1 << 4;
+  const TRANSITION_IN = 1;
+  const TRANSITION_OUT = 1 << 1;
+  const TRANSITION_GLOBAL = 1 << 2;
+  const TEMPLATE_FRAGMENT = 1;
+  const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
+  const UNINITIALIZED = Symbol();
+  const NAMESPACE_HTML = "http://www.w3.org/1999/xhtml";
+  let hydrating = false;
+  function reset(node) {
+    return;
+  }
   function equals(value) {
     return value === this.v;
   }
@@ -229,117 +342,807 @@
   function safe_equals(value) {
     return !safe_not_equal(value, this.v);
   }
-  function effect_in_teardown(rune) {
-    {
-      throw new Error("effect_in_teardown");
+  let async_mode_flag = false;
+  let legacy_mode_flag = false;
+  let tracing_mode_flag = false;
+  function enable_legacy_mode_flag() {
+    legacy_mode_flag = true;
+  }
+  let component_context = null;
+  function set_component_context(context) {
+    component_context = context;
+  }
+  function push(props, runes = false, fn) {
+    component_context = {
+      p: component_context,
+      c: null,
+      e: null,
+      s: props,
+      x: null,
+      l: legacy_mode_flag && !runes ? { s: null, u: null, $: [] } : null
+    };
+  }
+  function pop(component) {
+    var context = (
+      /** @type {ComponentContext} */
+      component_context
+    );
+    var effects = context.e;
+    if (effects !== null) {
+      context.e = null;
+      for (var fn of effects) {
+        create_user_effect(fn);
+      }
+    }
+    component_context = context.p;
+    return (
+      /** @type {T} */
+      {}
+    );
+  }
+  function is_runes() {
+    return !legacy_mode_flag || component_context !== null && component_context.l === null;
+  }
+  const adjustments = /* @__PURE__ */ new WeakMap();
+  function handle_error(error) {
+    var effect2 = active_effect;
+    if (effect2 === null) {
+      active_reaction.f |= ERROR_VALUE;
+      return error;
+    }
+    if ((effect2.f & EFFECT_RAN) === 0) {
+      if ((effect2.f & BOUNDARY_EFFECT) === 0) {
+        if (!effect2.parent && error instanceof Error) {
+          apply_adjustments(error);
+        }
+        throw error;
+      }
+      effect2.b.error(error);
+    } else {
+      invoke_error_boundary(error, effect2);
     }
   }
-  function effect_in_unowned_derived() {
-    {
-      throw new Error("effect_in_unowned_derived");
+  function invoke_error_boundary(error, effect2) {
+    while (effect2 !== null) {
+      if ((effect2.f & BOUNDARY_EFFECT) !== 0) {
+        try {
+          effect2.b.error(error);
+          return;
+        } catch (e) {
+          error = e;
+        }
+      }
+      effect2 = effect2.parent;
+    }
+    if (error instanceof Error) {
+      apply_adjustments(error);
+    }
+    throw error;
+  }
+  function apply_adjustments(error) {
+    const adjusted = adjustments.get(error);
+    if (adjusted) {
+      define_property(error, "message", {
+        value: adjusted.message
+      });
+      define_property(error, "stack", {
+        value: adjusted.stack
+      });
     }
   }
-  function effect_orphan(rune) {
-    {
-      throw new Error("effect_orphan");
+  let micro_tasks = [];
+  let idle_tasks = [];
+  function run_micro_tasks() {
+    var tasks = micro_tasks;
+    micro_tasks = [];
+    run_all(tasks);
+  }
+  function run_idle_tasks() {
+    var tasks = idle_tasks;
+    idle_tasks = [];
+    run_all(tasks);
+  }
+  function queue_micro_task(fn) {
+    if (micro_tasks.length === 0) {
+      queueMicrotask(run_micro_tasks);
+    }
+    micro_tasks.push(fn);
+  }
+  function flush_tasks() {
+    if (micro_tasks.length > 0) {
+      run_micro_tasks();
+    }
+    if (idle_tasks.length > 0) {
+      run_idle_tasks();
     }
   }
-  function effect_update_depth_exceeded() {
-    {
-      throw new Error("effect_update_depth_exceeded");
+  function get_pending_boundary() {
+    var boundary = (
+      /** @type {Effect} */
+      active_effect.b
+    );
+    while (boundary !== null && !boundary.has_pending_snippet()) {
+      boundary = boundary.parent;
+    }
+    if (boundary === null) {
+      await_outside_boundary();
+    }
+    return boundary;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function derived(fn) {
+    var flags = DERIVED | DIRTY;
+    var parent_derived = active_reaction !== null && (active_reaction.f & DERIVED) !== 0 ? (
+      /** @type {Derived} */
+      active_reaction
+    ) : null;
+    if (active_effect === null || parent_derived !== null && (parent_derived.f & UNOWNED) !== 0) {
+      flags |= UNOWNED;
+    } else {
+      active_effect.f |= EFFECT_PRESERVED;
+    }
+    const signal = {
+      ctx: component_context,
+      deps: null,
+      effects: null,
+      equals,
+      f: flags,
+      fn,
+      reactions: null,
+      rv: 0,
+      v: (
+        /** @type {V} */
+        UNINITIALIZED
+      ),
+      wv: 0,
+      parent: parent_derived ?? active_effect,
+      ac: null
+    };
+    return signal;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function async_derived(fn, location2) {
+    let parent = (
+      /** @type {Effect | null} */
+      active_effect
+    );
+    if (parent === null) {
+      async_derived_orphan();
+    }
+    var boundary = (
+      /** @type {Boundary} */
+      parent.b
+    );
+    var promise = (
+      /** @type {Promise<V>} */
+      /** @type {unknown} */
+      void 0
+    );
+    var signal = source(
+      /** @type {V} */
+      UNINITIALIZED
+    );
+    var prev2 = null;
+    var should_suspend = !active_reaction;
+    async_effect(() => {
+      try {
+        var p = fn();
+      } catch (error) {
+        p = Promise.reject(error);
+      }
+      var r2 = () => p;
+      promise = (prev2 == null ? void 0 : prev2.then(r2, r2)) ?? Promise.resolve(p);
+      prev2 = promise;
+      var batch = (
+        /** @type {Batch} */
+        current_batch
+      );
+      var pending = boundary.pending;
+      if (should_suspend) {
+        boundary.update_pending_count(1);
+        if (!pending) batch.increment();
+      }
+      const handler = (value, error = void 0) => {
+        prev2 = null;
+        if (!pending) batch.activate();
+        if (error) {
+          if (error !== STALE_REACTION) {
+            signal.f |= ERROR_VALUE;
+            internal_set(signal, error);
+          }
+        } else {
+          if ((signal.f & ERROR_VALUE) !== 0) {
+            signal.f ^= ERROR_VALUE;
+          }
+          internal_set(signal, value);
+        }
+        if (should_suspend) {
+          boundary.update_pending_count(-1);
+          if (!pending) batch.decrement();
+        }
+        unset_context();
+      };
+      promise.then(handler, (e) => handler(null, e || "unknown"));
+      if (batch) {
+        return () => {
+          queueMicrotask(() => batch.neuter());
+        };
+      }
+    });
+    return new Promise((fulfil) => {
+      function next2(p) {
+        function go() {
+          if (p === promise) {
+            fulfil(signal);
+          } else {
+            next2(promise);
+          }
+        }
+        p.then(go, go);
+      }
+      next2(promise);
+    });
+  }
+  // @__NO_SIDE_EFFECTS__
+  function derived_safe_equal(fn) {
+    const signal = /* @__PURE__ */ derived(fn);
+    signal.equals = safe_equals;
+    return signal;
+  }
+  function destroy_derived_effects(derived2) {
+    var effects = derived2.effects;
+    if (effects !== null) {
+      derived2.effects = null;
+      for (var i = 0; i < effects.length; i += 1) {
+        destroy_effect(
+          /** @type {Effect} */
+          effects[i]
+        );
+      }
     }
   }
-  function props_invalid_value(key) {
+  function get_derived_parent_effect(derived2) {
+    var parent = derived2.parent;
+    while (parent !== null) {
+      if ((parent.f & DERIVED) === 0) {
+        return (
+          /** @type {Effect} */
+          parent
+        );
+      }
+      parent = parent.parent;
+    }
+    return null;
+  }
+  function execute_derived(derived2) {
+    var value;
+    var prev_active_effect = active_effect;
+    set_active_effect(get_derived_parent_effect(derived2));
     {
-      throw new Error("props_invalid_value");
+      try {
+        destroy_derived_effects(derived2);
+        value = update_reaction(derived2);
+      } finally {
+        set_active_effect(prev_active_effect);
+      }
+    }
+    return value;
+  }
+  function update_derived(derived2) {
+    var value = execute_derived(derived2);
+    if (!derived2.equals(value)) {
+      derived2.v = value;
+      derived2.wv = increment_write_version();
+    }
+    if (is_destroying_effect) return;
+    if (batch_deriveds !== null) {
+      batch_deriveds.set(derived2, derived2.v);
+    } else {
+      var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
+      set_signal_status(derived2, status);
     }
   }
-  function state_descriptors_fixed() {
-    {
-      throw new Error("state_descriptors_fixed");
+  function flatten(sync, async, fn) {
+    const d = is_runes() ? derived : derived_safe_equal;
+    if (async.length === 0) {
+      fn(sync.map(d));
+      return;
+    }
+    var batch = current_batch;
+    var parent = (
+      /** @type {Effect} */
+      active_effect
+    );
+    var restore = capture();
+    var boundary = get_pending_boundary();
+    Promise.all(async.map((expression) => /* @__PURE__ */ async_derived(expression))).then((result) => {
+      batch == null ? void 0 : batch.activate();
+      restore();
+      try {
+        fn([...sync.map(d), ...result]);
+      } catch (error) {
+        if ((parent.f & DESTROYED) === 0) {
+          invoke_error_boundary(error, parent);
+        }
+      }
+      batch == null ? void 0 : batch.deactivate();
+      unset_context();
+    }).catch((error) => {
+      boundary.error(error);
+    });
+  }
+  function capture() {
+    var previous_effect = active_effect;
+    var previous_reaction = active_reaction;
+    var previous_component_context = component_context;
+    return function restore() {
+      set_active_effect(previous_effect);
+      set_active_reaction(previous_reaction);
+      set_component_context(previous_component_context);
+    };
+  }
+  function unset_context() {
+    set_active_effect(null);
+    set_active_reaction(null);
+    set_component_context(null);
+  }
+  const batches = /* @__PURE__ */ new Set();
+  let current_batch = null;
+  let batch_deriveds = null;
+  let effect_pending_updates = /* @__PURE__ */ new Set();
+  let queued_root_effects = [];
+  let last_scheduled_effect = null;
+  let is_flushing = false;
+  const _Batch = class _Batch {
+    constructor() {
+      __privateAdd(this, _Batch_instances);
+      /**
+       * The current values of any sources that are updated in this batch
+       * They keys of this map are identical to `this.#previous`
+       * @type {Map<Source, any>}
+       */
+      __privateAdd(this, _current, /* @__PURE__ */ new Map());
+      /**
+       * The values of any sources that are updated in this batch _before_ those updates took place.
+       * They keys of this map are identical to `this.#current`
+       * @type {Map<Source, any>}
+       */
+      __privateAdd(this, _previous, /* @__PURE__ */ new Map());
+      /**
+       * When the batch is committed (and the DOM is updated), we need to remove old branches
+       * and append new ones by calling the functions added inside (if/each/key/etc) blocks
+       * @type {Set<() => void>}
+       */
+      __privateAdd(this, _callbacks, /* @__PURE__ */ new Set());
+      /**
+       * The number of async effects that are currently in flight
+       */
+      __privateAdd(this, _pending, 0);
+      /**
+       * A deferred that resolves when the batch is committed, used with `settled()`
+       * TODO replace with Promise.withResolvers once supported widely enough
+       * @type {{ promise: Promise<void>, resolve: (value?: any) => void, reject: (reason: unknown) => void } | null}
+       */
+      __privateAdd(this, _deferred, null);
+      /**
+       * True if an async effect inside this batch resolved and
+       * its parent branch was already deleted
+       */
+      __privateAdd(this, _neutered, false);
+      /**
+       * Async effects (created inside `async_derived`) encountered during processing.
+       * These run after the rest of the batch has updated, since they should
+       * always have the latest values
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _async_effects, []);
+      /**
+       * The same as `#async_effects`, but for effects inside a newly-created
+       * `<svelte:boundary>` — these do not prevent the batch from committing
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _boundary_async_effects, []);
+      /**
+       * Template effects and `$effect.pre` effects, which run when
+       * a batch is committed
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _render_effects, []);
+      /**
+       * The same as `#render_effects`, but for `$effect` (which runs after)
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _effects, []);
+      /**
+       * Block effects, which may need to re-run on subsequent flushes
+       * in order to update internal sources (e.g. each block items)
+       * @type {Effect[]}
+       */
+      __privateAdd(this, _block_effects, []);
+      /**
+       * A set of branches that still exist, but will be destroyed when this batch
+       * is committed — we skip over these during `process`
+       * @type {Set<Effect>}
+       */
+      __publicField(this, "skipped_effects", /* @__PURE__ */ new Set());
+    }
+    /**
+     * Associate a change to a given source with the current
+     * batch, noting its previous and current values
+     * @param {Source} source
+     * @param {any} value
+     */
+    capture(source2, value) {
+      if (!__privateGet(this, _previous).has(source2)) {
+        __privateGet(this, _previous).set(source2, value);
+      }
+      __privateGet(this, _current).set(source2, source2.v);
+    }
+    activate() {
+      current_batch = this;
+    }
+    deactivate() {
+      current_batch = null;
+      for (const update of effect_pending_updates) {
+        effect_pending_updates.delete(update);
+        update();
+        if (current_batch !== null) {
+          break;
+        }
+      }
+    }
+    neuter() {
+      __privateSet(this, _neutered, true);
+    }
+    flush() {
+      if (queued_root_effects.length > 0) {
+        this.flush_effects();
+      } else {
+        __privateMethod(this, _Batch_instances, commit_fn).call(this);
+      }
+      if (current_batch !== this) {
+        return;
+      }
+      if (__privateGet(this, _pending) === 0) {
+        batches.delete(this);
+      }
+      this.deactivate();
+    }
+    flush_effects() {
+      var was_updating_effect = is_updating_effect;
+      is_flushing = true;
+      try {
+        var flush_count = 0;
+        set_is_updating_effect(true);
+        while (queued_root_effects.length > 0) {
+          if (flush_count++ > 1e3) {
+            var updates, entry;
+            if (DEV) ;
+            infinite_loop_guard();
+          }
+          __privateMethod(this, _Batch_instances, process_fn).call(this, queued_root_effects);
+          old_values.clear();
+        }
+      } finally {
+        is_flushing = false;
+        set_is_updating_effect(was_updating_effect);
+        last_scheduled_effect = null;
+      }
+    }
+    increment() {
+      __privateSet(this, _pending, __privateGet(this, _pending) + 1);
+    }
+    decrement() {
+      __privateSet(this, _pending, __privateGet(this, _pending) - 1);
+      if (__privateGet(this, _pending) === 0) {
+        for (const e of __privateGet(this, _render_effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        for (const e of __privateGet(this, _effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        for (const e of __privateGet(this, _block_effects)) {
+          set_signal_status(e, DIRTY);
+          schedule_effect(e);
+        }
+        __privateSet(this, _render_effects, []);
+        __privateSet(this, _effects, []);
+        this.flush();
+      } else {
+        this.deactivate();
+      }
+    }
+    /** @param {() => void} fn */
+    add_callback(fn) {
+      __privateGet(this, _callbacks).add(fn);
+    }
+    settled() {
+      return (__privateGet(this, _deferred) ?? __privateSet(this, _deferred, deferred())).promise;
+    }
+    static ensure(autoflush = true) {
+      if (current_batch === null) {
+        const batch = current_batch = new _Batch();
+        batches.add(current_batch);
+        if (autoflush) {
+          queueMicrotask(() => {
+            if (current_batch !== batch) {
+              return;
+            }
+            batch.flush();
+          });
+        }
+      }
+      return current_batch;
+    }
+  };
+  _current = new WeakMap();
+  _previous = new WeakMap();
+  _callbacks = new WeakMap();
+  _pending = new WeakMap();
+  _deferred = new WeakMap();
+  _neutered = new WeakMap();
+  _async_effects = new WeakMap();
+  _boundary_async_effects = new WeakMap();
+  _render_effects = new WeakMap();
+  _effects = new WeakMap();
+  _block_effects = new WeakMap();
+  _Batch_instances = new WeakSet();
+  /**
+   *
+   * @param {Effect[]} root_effects
+   */
+  process_fn = function(root_effects) {
+    var _a2;
+    queued_root_effects = [];
+    var current_values = null;
+    if (batches.size > 1) {
+      current_values = /* @__PURE__ */ new Map();
+      batch_deriveds = /* @__PURE__ */ new Map();
+      for (const [source2, current] of __privateGet(this, _current)) {
+        current_values.set(source2, { v: source2.v, wv: source2.wv });
+        source2.v = current;
+      }
+      for (const batch of batches) {
+        if (batch === this) continue;
+        for (const [source2, previous] of __privateGet(batch, _previous)) {
+          if (!current_values.has(source2)) {
+            current_values.set(source2, { v: source2.v, wv: source2.wv });
+            source2.v = previous;
+          }
+        }
+      }
+    }
+    for (const root2 of root_effects) {
+      __privateMethod(this, _Batch_instances, traverse_effect_tree_fn).call(this, root2);
+    }
+    if (__privateGet(this, _async_effects).length === 0 && __privateGet(this, _pending) === 0) {
+      var render_effects = __privateGet(this, _render_effects);
+      var effects = __privateGet(this, _effects);
+      __privateSet(this, _render_effects, []);
+      __privateSet(this, _effects, []);
+      __privateSet(this, _block_effects, []);
+      __privateMethod(this, _Batch_instances, commit_fn).call(this);
+      flush_queued_effects(render_effects);
+      flush_queued_effects(effects);
+      (_a2 = __privateGet(this, _deferred)) == null ? void 0 : _a2.resolve();
+    } else {
+      for (const e of __privateGet(this, _render_effects)) set_signal_status(e, CLEAN);
+      for (const e of __privateGet(this, _effects)) set_signal_status(e, CLEAN);
+      for (const e of __privateGet(this, _block_effects)) set_signal_status(e, CLEAN);
+    }
+    if (current_values) {
+      for (const [source2, { v, wv }] of current_values) {
+        if (source2.wv <= wv) {
+          source2.v = v;
+        }
+      }
+      batch_deriveds = null;
+    }
+    for (const effect2 of __privateGet(this, _async_effects)) {
+      update_effect(effect2);
+    }
+    for (const effect2 of __privateGet(this, _boundary_async_effects)) {
+      update_effect(effect2);
+    }
+    __privateSet(this, _async_effects, []);
+    __privateSet(this, _boundary_async_effects, []);
+  };
+  /**
+   * Traverse the effect tree, executing effects or stashing
+   * them for later execution as appropriate
+   * @param {Effect} root
+   */
+  traverse_effect_tree_fn = function(root2) {
+    var _a2;
+    root2.f ^= CLEAN;
+    var effect2 = root2.first;
+    while (effect2 !== null) {
+      var flags = effect2.f;
+      var is_branch = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) !== 0;
+      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
+      var skip = is_skippable_branch || (flags & INERT) !== 0 || this.skipped_effects.has(effect2);
+      if (!skip && effect2.fn !== null) {
+        if (is_branch) {
+          effect2.f ^= CLEAN;
+        } else if ((flags & EFFECT) !== 0) {
+          __privateGet(this, _effects).push(effect2);
+        } else if (is_dirty(effect2)) {
+          if ((flags & ASYNC) !== 0) {
+            var effects = ((_a2 = effect2.b) == null ? void 0 : _a2.pending) ? __privateGet(this, _boundary_async_effects) : __privateGet(this, _async_effects);
+            effects.push(effect2);
+          } else {
+            if ((effect2.f & BLOCK_EFFECT) !== 0) __privateGet(this, _block_effects).push(effect2);
+            update_effect(effect2);
+          }
+        }
+        var child2 = effect2.first;
+        if (child2 !== null) {
+          effect2 = child2;
+          continue;
+        }
+      }
+      var parent = effect2.parent;
+      effect2 = effect2.next;
+      while (effect2 === null && parent !== null) {
+        effect2 = parent.next;
+        parent = parent.parent;
+      }
+    }
+  };
+  /**
+   * Append and remove branches to/from the DOM
+   */
+  commit_fn = function() {
+    if (!__privateGet(this, _neutered)) {
+      for (const fn of __privateGet(this, _callbacks)) {
+        fn();
+      }
+    }
+    __privateGet(this, _callbacks).clear();
+  };
+  let Batch = _Batch;
+  function flushSync(fn) {
+    var result;
+    const batch = Batch.ensure(false);
+    while (true) {
+      flush_tasks();
+      if (queued_root_effects.length === 0) {
+        if (batch === current_batch) {
+          batch.flush();
+        }
+        last_scheduled_effect = null;
+        return (
+          /** @type {T} */
+          result
+        );
+      }
+      batch.flush_effects();
     }
   }
-  function state_prototype_fixed() {
-    {
-      throw new Error("state_prototype_fixed");
+  function infinite_loop_guard() {
+    try {
+      effect_update_depth_exceeded();
+    } catch (error) {
+      invoke_error_boundary(error, last_scheduled_effect);
     }
   }
-  function state_unsafe_local_read() {
-    {
-      throw new Error("state_unsafe_local_read");
+  function flush_queued_effects(effects) {
+    var length = effects.length;
+    if (length === 0) return;
+    for (var i = 0; i < length; i++) {
+      var effect2 = effects[i];
+      if ((effect2.f & (DESTROYED | INERT)) === 0) {
+        if (is_dirty(effect2)) {
+          var wv = write_version;
+          update_effect(effect2);
+          if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
+            if (effect2.teardown === null && effect2.ac === null) {
+              unlink_effect(effect2);
+            } else {
+              effect2.fn = null;
+            }
+          }
+          if (write_version > wv && (effect2.f & USER_EFFECT) !== 0) {
+            break;
+          }
+        }
+      }
+    }
+    for (; i < length; i += 1) {
+      schedule_effect(effects[i]);
     }
   }
-  function state_unsafe_mutation() {
-    {
-      throw new Error("state_unsafe_mutation");
+  function schedule_effect(signal) {
+    var effect2 = last_scheduled_effect = signal;
+    while (effect2.parent !== null) {
+      effect2 = effect2.parent;
+      var flags = effect2.f;
+      if (is_flushing && effect2 === active_effect && (flags & BLOCK_EFFECT) !== 0) {
+        return;
+      }
+      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+        if ((flags & CLEAN) === 0) return;
+        effect2.f ^= CLEAN;
+      }
     }
+    queued_root_effects.push(effect2);
   }
-  function source(v) {
-    return {
+  const old_values = /* @__PURE__ */ new Map();
+  function source(v, stack) {
+    var signal = {
       f: 0,
       // TODO ideally we could skip this altogether, but it causes type errors
       v,
       reactions: null,
       equals,
-      version: 0
+      rv: 0,
+      wv: 0
     };
-  }
-  function state(v) {
-    return /* @__PURE__ */ push_derived_source(source(v));
+    return signal;
   }
   // @__NO_SIDE_EFFECTS__
-  function mutable_source(initial_value, immutable = false) {
-    var _a;
+  function state(v, stack) {
+    const s = source(v);
+    push_reaction_value(s);
+    return s;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function mutable_source(initial_value, immutable = false, trackable = true) {
+    var _a2;
     const s = source(initial_value);
     if (!immutable) {
       s.equals = safe_equals;
     }
-    if (component_context !== null && component_context.l !== null) {
-      ((_a = component_context.l).s ?? (_a.s = [])).push(s);
+    if (legacy_mode_flag && trackable && component_context !== null && component_context.l !== null) {
+      ((_a2 = component_context.l).s ?? (_a2.s = [])).push(s);
     }
     return s;
   }
-  function mutable_state(v, immutable = false) {
-    return /* @__PURE__ */ push_derived_source(/* @__PURE__ */ mutable_source(v, immutable));
-  }
-  // @__NO_SIDE_EFFECTS__
-  function push_derived_source(source2) {
-    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-      if (derived_sources === null) {
-        set_derived_sources([source2]);
-      } else {
-        derived_sources.push(source2);
-      }
-    }
-    return source2;
-  }
-  function set(source2, value) {
-    if (active_reaction !== null && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT)) !== 0 && // If the source was created locally within the current derived, then
-    // we allow the mutation.
-    (derived_sources === null || !derived_sources.includes(source2))) {
+  function set(source2, value, should_proxy = false) {
+    if (active_reaction !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
+    // to ensure we error if state is set inside an inspect effect
+    (!untracking || (active_reaction.f & INSPECT_EFFECT) !== 0) && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT | ASYNC | INSPECT_EFFECT)) !== 0 && !(current_sources == null ? void 0 : current_sources.includes(source2))) {
       state_unsafe_mutation();
     }
-    return internal_set(source2, value);
+    let new_value = should_proxy ? proxy(value) : value;
+    return internal_set(source2, new_value);
   }
   function internal_set(source2, value) {
     if (!source2.equals(value)) {
+      var old_value = source2.v;
+      if (is_destroying_effect) {
+        old_values.set(source2, value);
+      } else {
+        old_values.set(source2, old_value);
+      }
       source2.v = value;
-      source2.version = increment_version();
+      const batch = Batch.ensure();
+      batch.capture(source2, old_value);
+      if ((source2.f & DERIVED) !== 0) {
+        if ((source2.f & DIRTY) !== 0) {
+          execute_derived(
+            /** @type {Derived} */
+            source2
+          );
+        }
+        set_signal_status(source2, (source2.f & UNOWNED) === 0 ? CLEAN : MAYBE_DIRTY);
+      }
+      source2.wv = increment_write_version();
       mark_reactions(source2, DIRTY);
-      if (is_runes() && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0) {
-        if (new_deps !== null && new_deps.includes(source2)) {
-          set_signal_status(active_effect, DIRTY);
-          schedule_effect(active_effect);
+      if (is_runes() && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
+        if (untracked_writes === null) {
+          set_untracked_writes([source2]);
         } else {
-          if (untracked_writes === null) {
-            set_untracked_writes([source2]);
-          } else {
-            untracked_writes.push(source2);
-          }
+          untracked_writes.push(source2);
         }
       }
     }
     return value;
+  }
+  function increment(source2) {
+    set(source2, source2.v + 1);
   }
   function mark_reactions(signal, status) {
     var reactions = signal.reactions;
@@ -368,24 +1171,7 @@
       }
     }
   }
-  const EACH_ITEM_REACTIVE = 1;
-  const EACH_INDEX_REACTIVE = 1 << 1;
-  const EACH_IS_CONTROLLED = 1 << 2;
-  const EACH_IS_ANIMATED = 1 << 3;
-  const EACH_ITEM_IMMUTABLE = 1 << 4;
-  const PROPS_IS_IMMUTABLE = 1;
-  const PROPS_IS_RUNES = 1 << 1;
-  const PROPS_IS_UPDATED = 1 << 2;
-  const PROPS_IS_BINDABLE = 1 << 3;
-  const PROPS_IS_LAZY_INITIAL = 1 << 4;
-  const TRANSITION_IN = 1;
-  const TRANSITION_OUT = 1 << 1;
-  const TRANSITION_GLOBAL = 1 << 2;
-  const TEMPLATE_FRAGMENT = 1;
-  const TEMPLATE_USE_IMPORT_NODE = 1 << 1;
-  const UNINITIALIZED = Symbol();
-  let hydrating = false;
-  function proxy(value, parent = null, prev2) {
+  function proxy(value) {
     if (typeof value !== "object" || value === null || STATE_SYMBOL in value) {
       return value;
     }
@@ -395,14 +1181,27 @@
     }
     var sources = /* @__PURE__ */ new Map();
     var is_proxied_array = is_array(value);
-    var version = source(0);
+    var version = /* @__PURE__ */ state(0);
+    var parent_version = update_version;
+    var with_parent = (fn) => {
+      if (update_version === parent_version) {
+        return fn();
+      }
+      var reaction = active_reaction;
+      var version2 = update_version;
+      set_active_reaction(null);
+      set_update_version(parent_version);
+      var result = fn();
+      set_active_reaction(reaction);
+      set_update_version(version2);
+      return result;
+    };
     if (is_proxied_array) {
-      sources.set("length", source(
+      sources.set("length", /* @__PURE__ */ state(
         /** @type {any[]} */
         value.length
       ));
     }
-    var metadata;
     return new Proxy(
       /** @type {any} */
       value,
@@ -413,10 +1212,13 @@
           }
           var s = sources.get(prop2);
           if (s === void 0) {
-            s = source(descriptor.value);
-            sources.set(prop2, s);
+            s = with_parent(() => {
+              var s2 = /* @__PURE__ */ state(descriptor.value);
+              sources.set(prop2, s2);
+              return s2;
+            });
           } else {
-            set(s, proxy(descriptor.value, metadata));
+            set(s, descriptor.value, true);
           }
           return true;
         },
@@ -424,33 +1226,29 @@
           var s = sources.get(prop2);
           if (s === void 0) {
             if (prop2 in target) {
-              sources.set(prop2, source(UNINITIALIZED));
+              const s2 = with_parent(() => /* @__PURE__ */ state(UNINITIALIZED));
+              sources.set(prop2, s2);
+              increment(version);
             }
           } else {
-            if (is_proxied_array && typeof prop2 === "string") {
-              var ls = (
-                /** @type {Source<number>} */
-                sources.get("length")
-              );
-              var n = Number(prop2);
-              if (Number.isInteger(n) && n < ls.v) {
-                set(ls, n);
-              }
-            }
             set(s, UNINITIALIZED);
-            update_version(version);
+            increment(version);
           }
           return true;
         },
         get(target, prop2, receiver) {
-          var _a;
+          var _a2;
           if (prop2 === STATE_SYMBOL) {
             return value;
           }
           var s = sources.get(prop2);
           var exists = prop2 in target;
-          if (s === void 0 && (!exists || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable))) {
-            s = source(proxy(exists ? target[prop2] : UNINITIALIZED, metadata));
+          if (s === void 0 && (!exists || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable))) {
+            s = with_parent(() => {
+              var p = proxy(exists ? target[prop2] : UNINITIALIZED);
+              var s2 = /* @__PURE__ */ state(p);
+              return s2;
+            });
             sources.set(prop2, s);
           }
           if (s !== void 0) {
@@ -479,15 +1277,19 @@
           return descriptor;
         },
         has(target, prop2) {
-          var _a;
+          var _a2;
           if (prop2 === STATE_SYMBOL) {
             return true;
           }
           var s = sources.get(prop2);
           var has = s !== void 0 && s.v !== UNINITIALIZED || Reflect.has(target, prop2);
-          if (s !== void 0 || active_effect !== null && (!has || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable))) {
+          if (s !== void 0 || active_effect !== null && (!has || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable))) {
             if (s === void 0) {
-              s = source(has ? proxy(target[prop2], metadata) : UNINITIALIZED);
+              s = with_parent(() => {
+                var p = has ? proxy(target[prop2]) : UNINITIALIZED;
+                var s2 = /* @__PURE__ */ state(p);
+                return s2;
+              });
               sources.set(prop2, s);
             }
             var value2 = get(s);
@@ -498,7 +1300,7 @@
           return has;
         },
         set(target, prop2, value2, receiver) {
-          var _a;
+          var _a2;
           var s = sources.get(prop2);
           var has = prop2 in target;
           if (is_proxied_array && prop2 === "length") {
@@ -508,20 +1310,21 @@
               if (other_s !== void 0) {
                 set(other_s, UNINITIALIZED);
               } else if (i in target) {
-                other_s = source(UNINITIALIZED);
+                other_s = with_parent(() => /* @__PURE__ */ state(UNINITIALIZED));
                 sources.set(i + "", other_s);
               }
             }
           }
           if (s === void 0) {
-            if (!has || ((_a = get_descriptor(target, prop2)) == null ? void 0 : _a.writable)) {
-              s = source(void 0);
-              set(s, proxy(value2, metadata));
+            if (!has || ((_a2 = get_descriptor(target, prop2)) == null ? void 0 : _a2.writable)) {
+              s = with_parent(() => /* @__PURE__ */ state(void 0));
+              set(s, proxy(value2));
               sources.set(prop2, s);
             }
           } else {
             has = s.v !== UNINITIALIZED;
-            set(s, proxy(value2, metadata));
+            var p = with_parent(() => proxy(value2));
+            set(s, p);
           }
           var descriptor = Reflect.getOwnPropertyDescriptor(target, prop2);
           if (descriptor == null ? void 0 : descriptor.set) {
@@ -538,7 +1341,7 @@
                 set(ls, n + 1);
               }
             }
-            update_version(version);
+            increment(version);
           }
           return true;
         },
@@ -561,10 +1364,8 @@
       }
     );
   }
-  function update_version(signal, d = 1) {
-    set(signal, signal.v + d);
-  }
   var $window;
+  var is_firefox;
   var first_child_getter;
   var next_sibling_getter;
   function init_operations() {
@@ -572,16 +1373,22 @@
       return;
     }
     $window = window;
+    is_firefox = /Firefox/.test(navigator.userAgent);
     var element_prototype = Element.prototype;
     var node_prototype = Node.prototype;
+    var text_prototype = Text.prototype;
     first_child_getter = get_descriptor(node_prototype, "firstChild").get;
     next_sibling_getter = get_descriptor(node_prototype, "nextSibling").get;
-    element_prototype.__click = void 0;
-    element_prototype.__className = "";
-    element_prototype.__attributes = null;
-    element_prototype.__styles = null;
-    element_prototype.__e = void 0;
-    Text.prototype.__t = void 0;
+    if (is_extensible(element_prototype)) {
+      element_prototype.__click = void 0;
+      element_prototype.__className = void 0;
+      element_prototype.__attributes = null;
+      element_prototype.__style = void 0;
+      element_prototype.__e = void 0;
+    }
+    if (is_extensible(text_prototype)) {
+      text_prototype.__t = void 0;
+    }
   }
   function create_text(value = "") {
     return document.createTextNode(value);
@@ -625,98 +1432,11 @@
   function clear_text_content(node) {
     node.textContent = "";
   }
-  // @__NO_SIDE_EFFECTS__
-  function derived(fn) {
-    var flags = DERIVED | DIRTY;
-    if (active_effect === null) {
-      flags |= UNOWNED;
-    } else {
-      active_effect.f |= EFFECT_HAS_DERIVED;
-    }
-    const signal = {
-      children: null,
-      ctx: component_context,
-      deps: null,
-      equals,
-      f: flags,
-      fn,
-      reactions: null,
-      v: (
-        /** @type {V} */
-        null
-      ),
-      version: 0,
-      parent: active_effect
-    };
-    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-      var derived2 = (
-        /** @type {Derived} */
-        active_reaction
-      );
-      (derived2.children ?? (derived2.children = [])).push(signal);
-    }
-    return signal;
-  }
-  // @__NO_SIDE_EFFECTS__
-  function derived_safe_equal(fn) {
-    const signal = /* @__PURE__ */ derived(fn);
-    signal.equals = safe_equals;
-    return signal;
-  }
-  function destroy_derived_children(derived2) {
-    var children = derived2.children;
-    if (children !== null) {
-      derived2.children = null;
-      for (var i = 0; i < children.length; i += 1) {
-        var child2 = children[i];
-        if ((child2.f & DERIVED) !== 0) {
-          destroy_derived(
-            /** @type {Derived} */
-            child2
-          );
-        } else {
-          destroy_effect(
-            /** @type {Effect} */
-            child2
-          );
-        }
-      }
-    }
-  }
-  function execute_derived(derived2) {
-    var value;
-    var prev_active_effect = active_effect;
-    set_active_effect(derived2.parent);
-    {
-      try {
-        destroy_derived_children(derived2);
-        value = update_reaction(derived2);
-      } finally {
-        set_active_effect(prev_active_effect);
-      }
-    }
-    return value;
-  }
-  function update_derived(derived2) {
-    var value = execute_derived(derived2);
-    var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
-    set_signal_status(derived2, status);
-    if (!derived2.equals(value)) {
-      derived2.v = value;
-      derived2.version = increment_version();
-    }
-  }
-  function destroy_derived(signal) {
-    destroy_derived_children(signal);
-    remove_reactions(signal, 0);
-    set_signal_status(signal, DESTROYED);
-    signal.v = signal.children = signal.deps = signal.ctx = signal.reactions = null;
-  }
   function validate_effect(rune) {
     if (active_effect === null && active_reaction === null) {
       effect_orphan();
     }
-    if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0) {
+    if (active_reaction !== null && (active_reaction.f & UNOWNED) !== 0 && active_effect === null) {
       effect_in_unowned_derived();
     }
     if (is_destroying_effect) {
@@ -734,12 +1454,13 @@
     }
   }
   function create_effect(type, fn, sync, push2 = true) {
-    var is_root = (type & ROOT_EFFECT) !== 0;
-    var parent_effect = active_effect;
+    var parent = active_effect;
+    if (parent !== null && (parent.f & INERT) !== 0) {
+      type |= INERT;
+    }
     var effect2 = {
       ctx: component_context,
       deps: null,
-      deriveds: null,
       nodes_start: null,
       nodes_end: null,
       f: type | DIRTY,
@@ -747,38 +1468,36 @@
       fn,
       last: null,
       next: null,
-      parent: is_root ? null : parent_effect,
+      parent,
+      b: parent && parent.b,
       prev: null,
       teardown: null,
       transitions: null,
-      version: 0
+      wv: 0,
+      ac: null
     };
     if (sync) {
-      var previously_flushing_effect = is_flushing_effect;
       try {
-        set_is_flushing_effect(true);
         update_effect(effect2);
         effect2.f |= EFFECT_RAN;
       } catch (e) {
         destroy_effect(effect2);
         throw e;
-      } finally {
-        set_is_flushing_effect(previously_flushing_effect);
       }
     } else if (fn !== null) {
       schedule_effect(effect2);
     }
-    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & EFFECT_HAS_DERIVED) === 0;
-    if (!inert && !is_root && push2) {
-      if (parent_effect !== null) {
-        push_effect(effect2, parent_effect);
+    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & EFFECT_PRESERVED) === 0;
+    if (!inert && push2) {
+      if (parent !== null) {
+        push_effect(effect2, parent);
       }
       if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
         var derived2 = (
           /** @type {Derived} */
           active_reaction
         );
-        (derived2.children ?? (derived2.children = [])).push(effect2);
+        (derived2.effects ?? (derived2.effects = [])).push(effect2);
       }
     }
     return effect2;
@@ -791,46 +1510,65 @@
   }
   function user_effect(fn) {
     validate_effect();
-    var defer = active_effect !== null && (active_effect.f & BRANCH_EFFECT) !== 0 && component_context !== null && !component_context.m;
+    var flags = (
+      /** @type {Effect} */
+      active_effect.f
+    );
+    var defer = !active_reaction && (flags & BRANCH_EFFECT) !== 0 && (flags & EFFECT_RAN) === 0;
     if (defer) {
       var context = (
         /** @type {ComponentContext} */
         component_context
       );
-      (context.e ?? (context.e = [])).push({
-        fn,
-        effect: active_effect,
-        reaction: active_reaction
-      });
+      (context.e ?? (context.e = [])).push(fn);
     } else {
-      var signal = effect(fn);
-      return signal;
+      return create_user_effect(fn);
     }
+  }
+  function create_user_effect(fn) {
+    return create_effect(EFFECT | USER_EFFECT, fn, false);
   }
   function user_pre_effect(fn) {
     validate_effect();
-    return render_effect(fn);
+    return create_effect(RENDER_EFFECT | USER_EFFECT, fn, true);
   }
-  function effect_root(fn) {
+  function component_root(fn) {
+    Batch.ensure();
     const effect2 = create_effect(ROOT_EFFECT, fn, true);
-    return () => {
-      destroy_effect(effect2);
+    return (options = {}) => {
+      return new Promise((fulfil) => {
+        if (options.outro) {
+          pause_effect(effect2, () => {
+            destroy_effect(effect2);
+            fulfil(void 0);
+          });
+        } else {
+          destroy_effect(effect2);
+          fulfil(void 0);
+        }
+      });
     };
   }
   function effect(fn) {
     return create_effect(EFFECT, fn, false);
   }
-  function render_effect(fn) {
-    return create_effect(RENDER_EFFECT, fn, true);
+  function async_effect(fn) {
+    return create_effect(ASYNC | EFFECT_PRESERVED, fn, true);
   }
-  function template_effect(fn) {
-    return block(fn);
+  function render_effect(fn, flags = 0) {
+    return create_effect(RENDER_EFFECT | flags, fn, true);
+  }
+  function template_effect(fn, sync = [], async = []) {
+    flatten(sync, async, (values) => {
+      create_effect(RENDER_EFFECT, () => fn(...values.map(get)), true);
+    });
   }
   function block(fn, flags = 0) {
-    return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
+    var effect2 = create_effect(BLOCK_EFFECT | flags, fn, true);
+    return effect2;
   }
   function branch(fn, push2 = true) {
-    return create_effect(RENDER_EFFECT | BRANCH_EFFECT, fn, true, push2);
+    return create_effect(BRANCH_EFFECT, fn, true, push2);
   }
   function execute_effect_teardown(effect2) {
     var teardown2 = effect2.teardown;
@@ -847,21 +1585,18 @@
       }
     }
   }
-  function destroy_effect_deriveds(signal) {
-    var deriveds = signal.deriveds;
-    if (deriveds !== null) {
-      signal.deriveds = null;
-      for (var i = 0; i < deriveds.length; i += 1) {
-        destroy_derived(deriveds[i]);
-      }
-    }
-  }
   function destroy_effect_children(signal, remove_dom = false) {
+    var _a2;
     var effect2 = signal.first;
     signal.first = signal.last = null;
     while (effect2 !== null) {
+      (_a2 = effect2.ac) == null ? void 0 : _a2.abort(STALE_REACTION);
       var next2 = effect2.next;
-      destroy_effect(effect2, remove_dom);
+      if ((effect2.f & ROOT_EFFECT) !== 0) {
+        effect2.parent = null;
+      } else {
+        destroy_effect(effect2, remove_dom);
+      }
       effect2 = next2;
     }
   }
@@ -877,20 +1612,14 @@
   }
   function destroy_effect(effect2, remove_dom = true) {
     var removed = false;
-    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null) {
-      var node = effect2.nodes_start;
-      var end = effect2.nodes_end;
-      while (node !== null) {
-        var next2 = node === end ? null : (
-          /** @type {TemplateNode} */
-          /* @__PURE__ */ get_next_sibling(node)
-        );
-        node.remove();
-        node = next2;
-      }
+    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null && effect2.nodes_end !== null) {
+      remove_effect_dom(
+        effect2.nodes_start,
+        /** @type {TemplateNode} */
+        effect2.nodes_end
+      );
       removed = true;
     }
-    destroy_effect_deriveds(effect2);
     destroy_effect_children(effect2, remove_dom && !removed);
     remove_reactions(effect2, 0);
     set_signal_status(effect2, DESTROYED);
@@ -905,7 +1634,17 @@
     if (parent !== null && parent.first !== null) {
       unlink_effect(effect2);
     }
-    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.parent = effect2.fn = effect2.nodes_start = effect2.nodes_end = null;
+    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.fn = effect2.nodes_start = effect2.nodes_end = effect2.ac = null;
+  }
+  function remove_effect_dom(node, end) {
+    while (node !== null) {
+      var next2 = node === end ? null : (
+        /** @type {TemplateNode} */
+        /* @__PURE__ */ get_next_sibling(node)
+      );
+      node.remove();
+      node = next2;
+    }
   }
   function unlink_effect(effect2) {
     var parent = effect2.parent;
@@ -961,8 +1700,9 @@
   function resume_children(effect2, local) {
     if ((effect2.f & INERT) === 0) return;
     effect2.f ^= INERT;
-    if (check_dirtiness(effect2)) {
-      update_effect(effect2);
+    if ((effect2.f & CLEAN) === 0) {
+      set_signal_status(effect2, DIRTY);
+      schedule_effect(effect2);
     }
     var child2 = effect2.first;
     while (child2 !== null) {
@@ -979,46 +1719,16 @@
       }
     }
   }
-  let is_micro_task_queued$1 = false;
-  let current_queued_micro_tasks = [];
-  function process_micro_tasks() {
-    is_micro_task_queued$1 = false;
-    const tasks = current_queued_micro_tasks.slice();
-    current_queued_micro_tasks = [];
-    run_all(tasks);
+  let is_updating_effect = false;
+  function set_is_updating_effect(value) {
+    is_updating_effect = value;
   }
-  function queue_micro_task(fn) {
-    if (!is_micro_task_queued$1) {
-      is_micro_task_queued$1 = true;
-      queueMicrotask(process_micro_tasks);
-    }
-    current_queued_micro_tasks.push(fn);
-  }
-  function flush_tasks() {
-    if (is_micro_task_queued$1) {
-      process_micro_tasks();
-    }
-  }
-  function lifecycle_outside_component(name) {
-    {
-      throw new Error("lifecycle_outside_component");
-    }
-  }
-  const FLUSH_MICROTASK = 0;
-  const FLUSH_SYNC = 1;
-  let scheduler_mode = FLUSH_MICROTASK;
-  let is_micro_task_queued = false;
-  let is_flushing_effect = false;
   let is_destroying_effect = false;
-  function set_is_flushing_effect(value) {
-    is_flushing_effect = value;
-  }
   function set_is_destroying_effect(value) {
     is_destroying_effect = value;
   }
-  let queued_root_effects = [];
-  let flush_count = 0;
   let active_reaction = null;
+  let untracking = false;
   function set_active_reaction(reaction) {
     active_reaction = reaction;
   }
@@ -1026,9 +1736,15 @@
   function set_active_effect(effect2) {
     active_effect = effect2;
   }
-  let derived_sources = null;
-  function set_derived_sources(sources) {
-    derived_sources = sources;
+  let current_sources = null;
+  function push_reaction_value(value) {
+    if (active_reaction !== null && !async_mode_flag) {
+      if (current_sources === null) {
+        current_sources = [value];
+      } else {
+        current_sources.push(value);
+      }
+    }
   }
   let new_deps = null;
   let skipped_deps = 0;
@@ -1036,20 +1752,18 @@
   function set_untracked_writes(value) {
     untracked_writes = value;
   }
-  let current_version = 0;
+  let write_version = 1;
+  let read_version = 0;
+  let update_version = read_version;
+  function set_update_version(value) {
+    update_version = value;
+  }
   let skip_reaction = false;
-  let component_context = null;
-  function set_component_context(context) {
-    component_context = context;
+  function increment_write_version() {
+    return ++write_version;
   }
-  function increment_version() {
-    return ++current_version;
-  }
-  function is_runes() {
-    return component_context !== null && component_context.l === null;
-  }
-  function check_dirtiness(reaction) {
-    var _a, _b;
+  function is_dirty(reaction) {
+    var _a2;
     var flags = reaction.f;
     if ((flags & DIRTY) !== 0) {
       return true;
@@ -1059,15 +1773,32 @@
       var is_unowned = (flags & UNOWNED) !== 0;
       if (dependencies !== null) {
         var i;
-        if ((flags & DISCONNECTED) !== 0) {
-          for (i = 0; i < dependencies.length; i++) {
-            ((_a = dependencies[i]).reactions ?? (_a.reactions = [])).push(reaction);
+        var dependency;
+        var is_disconnected = (flags & DISCONNECTED) !== 0;
+        var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
+        var length = dependencies.length;
+        if ((is_disconnected || is_unowned_connected) && (active_effect === null || (active_effect.f & DESTROYED) === 0)) {
+          var derived2 = (
+            /** @type {Derived} */
+            reaction
+          );
+          var parent = derived2.parent;
+          for (i = 0; i < length; i++) {
+            dependency = dependencies[i];
+            if (is_disconnected || !((_a2 = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _a2.includes(derived2))) {
+              (dependency.reactions ?? (dependency.reactions = [])).push(derived2);
+            }
           }
-          reaction.f ^= DISCONNECTED;
+          if (is_disconnected) {
+            derived2.f ^= DISCONNECTED;
+          }
+          if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
+            derived2.f ^= UNOWNED;
+          }
         }
-        for (i = 0; i < dependencies.length; i++) {
-          var dependency = dependencies[i];
-          if (check_dirtiness(
+        for (i = 0; i < length; i++) {
+          dependency = dependencies[i];
+          if (is_dirty(
             /** @type {Derived} */
             dependency
           )) {
@@ -1076,44 +1807,73 @@
               dependency
             );
           }
-          if (is_unowned && active_effect !== null && !skip_reaction && !((_b = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _b.includes(reaction))) {
-            (dependency.reactions ?? (dependency.reactions = [])).push(reaction);
-          }
-          if (dependency.version > reaction.version) {
+          if (dependency.wv > reaction.wv) {
             return true;
           }
         }
       }
-      if (!is_unowned) {
+      if (!is_unowned || active_effect !== null && !skip_reaction) {
         set_signal_status(reaction, CLEAN);
       }
     }
     return false;
   }
-  function handle_error(error, effect2, component_context2) {
-    {
-      throw error;
+  function schedule_possible_effect_self_invalidation(signal, effect2, root2 = true) {
+    var reactions = signal.reactions;
+    if (reactions === null) return;
+    if (current_sources == null ? void 0 : current_sources.includes(signal)) {
+      return;
+    }
+    for (var i = 0; i < reactions.length; i++) {
+      var reaction = reactions[i];
+      if ((reaction.f & DERIVED) !== 0) {
+        schedule_possible_effect_self_invalidation(
+          /** @type {Derived} */
+          reaction,
+          effect2,
+          false
+        );
+      } else if (effect2 === reaction) {
+        if (root2) {
+          set_signal_status(reaction, DIRTY);
+        } else if ((reaction.f & CLEAN) !== 0) {
+          set_signal_status(reaction, MAYBE_DIRTY);
+        }
+        schedule_effect(
+          /** @type {Effect} */
+          reaction
+        );
+      }
     }
   }
   function update_reaction(reaction) {
-    var _a;
+    var _a2;
     var previous_deps = new_deps;
     var previous_skipped_deps = skipped_deps;
     var previous_untracked_writes = untracked_writes;
     var previous_reaction = active_reaction;
     var previous_skip_reaction = skip_reaction;
-    var prev_derived_sources = derived_sources;
+    var previous_sources = current_sources;
     var previous_component_context = component_context;
+    var previous_untracking = untracking;
+    var previous_update_version = update_version;
     var flags = reaction.f;
     new_deps = /** @type {null | Value[]} */
     null;
     skipped_deps = 0;
     untracked_writes = null;
+    skip_reaction = (flags & UNOWNED) !== 0 && (untracking || !is_updating_effect || active_reaction === null);
     active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
-    skip_reaction = !is_flushing_effect && (flags & UNOWNED) !== 0;
-    derived_sources = null;
-    component_context = reaction.ctx;
+    current_sources = null;
+    set_component_context(reaction.ctx);
+    untracking = false;
+    update_version = ++read_version;
+    if (reaction.ac !== null) {
+      reaction.ac.abort(STALE_REACTION);
+      reaction.ac = null;
+    }
     try {
+      reaction.f |= REACTION_IS_UPDATING;
       var result = (
         /** @type {Function} */
         (0, reaction.fn)()
@@ -1130,30 +1890,61 @@
         } else {
           reaction.deps = deps = new_deps;
         }
-        if (!skip_reaction) {
+        if (!skip_reaction || // Deriveds that already have reactions can cleanup, so we still add them as reactions
+        (flags & DERIVED) !== 0 && /** @type {import('#client').Derived} */
+        reaction.reactions !== null) {
           for (i = skipped_deps; i < deps.length; i++) {
-            ((_a = deps[i]).reactions ?? (_a.reactions = [])).push(reaction);
+            ((_a2 = deps[i]).reactions ?? (_a2.reactions = [])).push(reaction);
           }
         }
       } else if (deps !== null && skipped_deps < deps.length) {
         remove_reactions(reaction, skipped_deps);
         deps.length = skipped_deps;
       }
+      if (is_runes() && untracked_writes !== null && !untracking && deps !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
+        for (i = 0; i < /** @type {Source[]} */
+        untracked_writes.length; i++) {
+          schedule_possible_effect_self_invalidation(
+            untracked_writes[i],
+            /** @type {Effect} */
+            reaction
+          );
+        }
+      }
+      if (previous_reaction !== null && previous_reaction !== reaction) {
+        read_version++;
+        if (untracked_writes !== null) {
+          if (previous_untracked_writes === null) {
+            previous_untracked_writes = untracked_writes;
+          } else {
+            previous_untracked_writes.push(.../** @type {Source[]} */
+            untracked_writes);
+          }
+        }
+      }
+      if ((reaction.f & ERROR_VALUE) !== 0) {
+        reaction.f ^= ERROR_VALUE;
+      }
       return result;
+    } catch (error) {
+      return handle_error(error);
     } finally {
+      reaction.f ^= REACTION_IS_UPDATING;
       new_deps = previous_deps;
       skipped_deps = previous_skipped_deps;
       untracked_writes = previous_untracked_writes;
       active_reaction = previous_reaction;
       skip_reaction = previous_skip_reaction;
-      derived_sources = prev_derived_sources;
-      component_context = previous_component_context;
+      current_sources = previous_sources;
+      set_component_context(previous_component_context);
+      untracking = previous_untracking;
+      update_version = previous_update_version;
     }
   }
   function remove_reaction(signal, dependency) {
     let reactions = dependency.reactions;
     if (reactions !== null) {
-      var index2 = reactions.indexOf(signal);
+      var index2 = index_of.call(reactions, signal);
       if (index2 !== -1) {
         var new_length = reactions.length - 1;
         if (new_length === 0) {
@@ -1172,6 +1963,10 @@
       if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
         dependency.f ^= DISCONNECTED;
       }
+      destroy_derived_effects(
+        /** @type {Derived} **/
+        dependency
+      );
       remove_reactions(
         /** @type {Derived} **/
         dependency,
@@ -1193,9 +1988,10 @@
     }
     set_signal_status(effect2, CLEAN);
     var previous_effect = active_effect;
+    var was_updating_effect = is_updating_effect;
     active_effect = effect2;
+    is_updating_effect = true;
     try {
-      destroy_effect_deriveds(effect2);
       if ((flags & BLOCK_EFFECT) !== 0) {
         destroy_block_effect_children(effect2);
       } else {
@@ -1204,274 +2000,111 @@
       execute_effect_teardown(effect2);
       var teardown2 = update_reaction(effect2);
       effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
-      effect2.version = current_version;
-      if (DEV) ;
-    } catch (error) {
-      handle_error(
-        /** @type {Error} */
-        error
-      );
+      effect2.wv = write_version;
+      var dep;
+      if (DEV && tracing_mode_flag && (effect2.f & DIRTY) !== 0 && effect2.deps !== null) ;
     } finally {
+      is_updating_effect = was_updating_effect;
       active_effect = previous_effect;
     }
   }
-  function infinite_loop_guard() {
-    if (flush_count > 1e3) {
-      flush_count = 0;
-      {
-        effect_update_depth_exceeded();
-      }
-    }
-    flush_count++;
-  }
-  function flush_queued_root_effects(root_effects) {
-    var length = root_effects.length;
-    if (length === 0) {
-      return;
-    }
-    infinite_loop_guard();
-    var previously_flushing_effect = is_flushing_effect;
-    is_flushing_effect = true;
-    try {
-      for (var i = 0; i < length; i++) {
-        var effect2 = root_effects[i];
-        if ((effect2.f & CLEAN) === 0) {
-          effect2.f ^= CLEAN;
-        }
-        var collected_effects = [];
-        process_effects(effect2, collected_effects);
-        flush_queued_effects(collected_effects);
-      }
-    } finally {
-      is_flushing_effect = previously_flushing_effect;
-    }
-  }
-  function flush_queued_effects(effects) {
-    var length = effects.length;
-    if (length === 0) return;
-    for (var i = 0; i < length; i++) {
-      var effect2 = effects[i];
-      if ((effect2.f & (DESTROYED | INERT)) === 0 && check_dirtiness(effect2)) {
-        update_effect(effect2);
-        if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
-          if (effect2.teardown === null) {
-            unlink_effect(effect2);
-          } else {
-            effect2.fn = null;
-          }
-        }
-      }
-    }
-  }
-  function process_deferred() {
-    is_micro_task_queued = false;
-    if (flush_count > 1001) {
-      return;
-    }
-    const previous_queued_root_effects = queued_root_effects;
-    queued_root_effects = [];
-    flush_queued_root_effects(previous_queued_root_effects);
-    if (!is_micro_task_queued) {
-      flush_count = 0;
-    }
-  }
-  function schedule_effect(signal) {
-    if (scheduler_mode === FLUSH_MICROTASK) {
-      if (!is_micro_task_queued) {
-        is_micro_task_queued = true;
-        queueMicrotask(process_deferred);
-      }
-    }
-    var effect2 = signal;
-    while (effect2.parent !== null) {
-      effect2 = effect2.parent;
-      var flags = effect2.f;
-      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
-        if ((flags & CLEAN) === 0) return;
-        effect2.f ^= CLEAN;
-      }
-    }
-    queued_root_effects.push(effect2);
-  }
-  function process_effects(effect2, collected_effects) {
-    var current_effect = effect2.first;
-    var effects = [];
-    main_loop: while (current_effect !== null) {
-      var flags = current_effect.f;
-      var is_branch = (flags & BRANCH_EFFECT) !== 0;
-      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
-      if (!is_skippable_branch && (flags & INERT) === 0) {
-        if ((flags & RENDER_EFFECT) !== 0) {
-          if (is_branch) {
-            current_effect.f ^= CLEAN;
-          } else if (check_dirtiness(current_effect)) {
-            update_effect(current_effect);
-          }
-          var child2 = current_effect.first;
-          if (child2 !== null) {
-            current_effect = child2;
-            continue;
-          }
-        } else if ((flags & EFFECT) !== 0) {
-          effects.push(current_effect);
-        }
-      }
-      var sibling2 = current_effect.next;
-      if (sibling2 === null) {
-        let parent = current_effect.parent;
-        while (parent !== null) {
-          if (effect2 === parent) {
-            break main_loop;
-          }
-          var parent_sibling = parent.next;
-          if (parent_sibling !== null) {
-            current_effect = parent_sibling;
-            continue main_loop;
-          }
-          parent = parent.parent;
-        }
-      }
-      current_effect = sibling2;
-    }
-    for (var i = 0; i < effects.length; i++) {
-      child2 = effects[i];
-      collected_effects.push(child2);
-      process_effects(child2, collected_effects);
-    }
-  }
-  function flush_sync(fn) {
-    var previous_scheduler_mode = scheduler_mode;
-    var previous_queued_root_effects = queued_root_effects;
-    try {
-      infinite_loop_guard();
-      const root_effects = [];
-      scheduler_mode = FLUSH_SYNC;
-      queued_root_effects = root_effects;
-      is_micro_task_queued = false;
-      flush_queued_root_effects(previous_queued_root_effects);
-      var result = fn == null ? void 0 : fn();
-      flush_tasks();
-      if (queued_root_effects.length > 0 || root_effects.length > 0) {
-        flush_sync();
-      }
-      flush_count = 0;
-      if (DEV) ;
-      return result;
-    } finally {
-      scheduler_mode = previous_scheduler_mode;
-      queued_root_effects = previous_queued_root_effects;
-    }
-  }
   function get(signal) {
-    var _a;
     var flags = signal.f;
     var is_derived = (flags & DERIVED) !== 0;
-    if (is_derived && (flags & DESTROYED) !== 0) {
-      var value = execute_derived(
-        /** @type {Derived} */
-        signal
-      );
-      destroy_derived(
-        /** @type {Derived} */
-        signal
-      );
-      return value;
-    }
-    if (active_reaction !== null) {
-      if (derived_sources !== null && derived_sources.includes(signal)) {
-        state_unsafe_local_read();
-      }
-      var deps = active_reaction.deps;
-      if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
-        skipped_deps++;
-      } else if (new_deps === null) {
-        new_deps = [signal];
-      } else {
-        new_deps.push(signal);
-      }
-      if (untracked_writes !== null && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0 && untracked_writes.includes(signal)) {
-        set_signal_status(active_effect, DIRTY);
-        schedule_effect(active_effect);
+    if (active_reaction !== null && !untracking) {
+      var destroyed = active_effect !== null && (active_effect.f & DESTROYED) !== 0;
+      if (!destroyed && !(current_sources == null ? void 0 : current_sources.includes(signal))) {
+        var deps = active_reaction.deps;
+        if ((active_reaction.f & REACTION_IS_UPDATING) !== 0) {
+          if (signal.rv < read_version) {
+            signal.rv = read_version;
+            if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
+              skipped_deps++;
+            } else if (new_deps === null) {
+              new_deps = [signal];
+            } else if (!skip_reaction || !new_deps.includes(signal)) {
+              new_deps.push(signal);
+            }
+          }
+        } else {
+          (active_reaction.deps ?? (active_reaction.deps = [])).push(signal);
+          var reactions = signal.reactions;
+          if (reactions === null) {
+            signal.reactions = [active_reaction];
+          } else if (!reactions.includes(active_reaction)) {
+            reactions.push(active_reaction);
+          }
+        }
       }
     } else if (is_derived && /** @type {Derived} */
-    signal.deps === null) {
+    signal.deps === null && /** @type {Derived} */
+    signal.effects === null) {
       var derived2 = (
         /** @type {Derived} */
         signal
       );
       var parent = derived2.parent;
-      if (parent !== null && !((_a = parent.deriveds) == null ? void 0 : _a.includes(derived2))) {
-        (parent.deriveds ?? (parent.deriveds = [])).push(derived2);
+      if (parent !== null && (parent.f & UNOWNED) === 0) {
+        derived2.f ^= UNOWNED;
       }
     }
-    if (is_derived) {
+    if (is_destroying_effect) {
+      if (old_values.has(signal)) {
+        return old_values.get(signal);
+      }
+      if (is_derived) {
+        derived2 = /** @type {Derived} */
+        signal;
+        var value = derived2.v;
+        if ((derived2.f & CLEAN) !== 0 || depends_on_old_values(derived2)) {
+          value = execute_derived(derived2);
+        }
+        old_values.set(derived2, value);
+        return value;
+      }
+    } else if (is_derived) {
       derived2 = /** @type {Derived} */
       signal;
-      if (check_dirtiness(derived2)) {
+      if (batch_deriveds == null ? void 0 : batch_deriveds.has(derived2)) {
+        return batch_deriveds.get(derived2);
+      }
+      if (is_dirty(derived2)) {
         update_derived(derived2);
       }
     }
+    if ((signal.f & ERROR_VALUE) !== 0) {
+      throw signal.v;
+    }
     return signal.v;
   }
+  function depends_on_old_values(derived2) {
+    if (derived2.v === UNINITIALIZED) return true;
+    if (derived2.deps === null) return false;
+    for (const dep of derived2.deps) {
+      if (old_values.has(dep)) {
+        return true;
+      }
+      if ((dep.f & DERIVED) !== 0 && depends_on_old_values(
+        /** @type {Derived} */
+        dep
+      )) {
+        return true;
+      }
+    }
+    return false;
+  }
   function untrack(fn) {
-    const previous_reaction = active_reaction;
+    var previous_untracking = untracking;
     try {
-      active_reaction = null;
+      untracking = true;
       return fn();
     } finally {
-      active_reaction = previous_reaction;
+      untracking = previous_untracking;
     }
   }
   const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
   function set_signal_status(signal, status) {
     signal.f = signal.f & STATUS_MASK | status;
-  }
-  function push(props, runes = false, fn) {
-    component_context = {
-      p: component_context,
-      c: null,
-      e: null,
-      m: false,
-      s: props,
-      x: null,
-      l: null
-    };
-    if (!runes) {
-      component_context.l = {
-        s: null,
-        u: null,
-        r1: [],
-        r2: source(false)
-      };
-    }
-  }
-  function pop(component) {
-    const context_stack_item = component_context;
-    if (context_stack_item !== null) {
-      const component_effects = context_stack_item.e;
-      if (component_effects !== null) {
-        var previous_effect = active_effect;
-        var previous_reaction = active_reaction;
-        context_stack_item.e = null;
-        try {
-          for (var i = 0; i < component_effects.length; i++) {
-            var component_effect = component_effects[i];
-            set_active_effect(component_effect.effect);
-            set_active_reaction(component_effect.reaction);
-            effect(component_effect.fn);
-          }
-        } finally {
-          set_active_effect(previous_effect);
-          set_active_reaction(previous_reaction);
-        }
-      }
-      component_context = context_stack_item.p;
-      context_stack_item.m = true;
-    }
-    return (
-      /** @type {T} */
-      {}
-    );
   }
   function deep_read_state(value) {
     if (typeof value !== "object" || !value || value instanceof EventTarget) {
@@ -1516,24 +2149,71 @@
       }
     }
   }
+  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
+  function is_passive_event(name) {
+    return PASSIVE_EVENTS.includes(name);
+  }
+  let listening_to_form_reset = false;
+  function add_form_reset_listener() {
+    if (!listening_to_form_reset) {
+      listening_to_form_reset = true;
+      document.addEventListener(
+        "reset",
+        (evt) => {
+          Promise.resolve().then(() => {
+            var _a2;
+            if (!evt.defaultPrevented) {
+              for (
+                const e of
+                /**@type {HTMLFormElement} */
+                evt.target.elements
+              ) {
+                (_a2 = e.__on_r) == null ? void 0 : _a2.call(e);
+              }
+            }
+          });
+        },
+        // In the capture phase to guarantee we get noticed of it (no possiblity of stopPropagation)
+        { capture: true }
+      );
+    }
+  }
+  function without_reactive_context(fn) {
+    var previous_reaction = active_reaction;
+    var previous_effect = active_effect;
+    set_active_reaction(null);
+    set_active_effect(null);
+    try {
+      return fn();
+    } finally {
+      set_active_reaction(previous_reaction);
+      set_active_effect(previous_effect);
+    }
+  }
+  function listen_to_event_and_reset_event(element, event2, handler, on_reset = handler) {
+    element.addEventListener(event2, () => without_reactive_context(handler));
+    const prev2 = element.__on_r;
+    if (prev2) {
+      element.__on_r = () => {
+        prev2();
+        on_reset(true);
+      };
+    } else {
+      element.__on_r = () => on_reset(true);
+    }
+    add_form_reset_listener();
+  }
   const all_registered_events = /* @__PURE__ */ new Set();
   const root_event_handles = /* @__PURE__ */ new Set();
-  function create_event(event_name, dom, handler, options) {
+  function create_event(event_name, dom, handler, options = {}) {
     function target_handler(event2) {
       if (!options.capture) {
         handle_event_propagation.call(dom, event2);
       }
       if (!event2.cancelBubble) {
-        var previous_reaction = active_reaction;
-        var previous_effect = active_effect;
-        set_active_reaction(null);
-        set_active_effect(null);
-        try {
-          return handler.call(this, event2);
-        } finally {
-          set_active_reaction(previous_reaction);
-          set_active_effect(previous_effect);
-        }
+        return without_reactive_context(() => {
+          return handler == null ? void 0 : handler.call(this, event2);
+        });
       }
     }
     if (event_name.startsWith("pointer") || event_name.startsWith("touch") || event_name === "wheel") {
@@ -1545,10 +2225,13 @@
     }
     return target_handler;
   }
-  function event(event_name, dom, handler, capture, passive) {
-    var options = { capture, passive };
+  function event(event_name, dom, handler, capture2, passive) {
+    var options = { capture: capture2, passive };
     var target_handler = create_event(event_name, dom, handler, options);
-    if (dom === document.body || dom === window || dom === document) {
+    if (dom === document.body || // @ts-ignore
+    dom === window || // @ts-ignore
+    dom === document || // Firefox has quirky behavior, it can happen that we still get "canplay" events when the element is already removed
+    dom instanceof HTMLMediaElement) {
       teardown(() => {
         dom.removeEventListener(event_name, target_handler, options);
       });
@@ -1563,14 +2246,14 @@
     }
   }
   function handle_event_propagation(event2) {
-    var _a;
+    var _a2;
     var handler_element = this;
     var owner_document = (
       /** @type {Node} */
       handler_element.ownerDocument
     );
     var event_name = event2.type;
-    var path = ((_a = event2.composedPath) == null ? void 0 : _a.call(event2)) || [];
+    var path = ((_a2 = event2.composedPath) == null ? void 0 : _a2.call(event2)) || [];
     var current_target = (
       /** @type {null | Element} */
       path[0] || event2.target
@@ -1613,8 +2296,10 @@
         current_target.host || null;
         try {
           var delegated = current_target["__" + event_name];
-          if (delegated !== void 0 && !/** @type {any} */
-          current_target.disabled) {
+          if (delegated != null && (!/** @type {any} */
+          current_target.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
+          // -> the target could not have been disabled because it emits the event in the first place
+          event2.target === current_target)) {
             if (is_array(delegated)) {
               var [fn, ...data] = delegated;
               fn.apply(current_target, [event2, ...data]);
@@ -1651,7 +2336,7 @@
   }
   function create_fragment_from_html(html2) {
     var elem = document.createElement("template");
-    elem.innerHTML = html2;
+    elem.innerHTML = html2.replaceAll("<!>", "<!---->");
     return elem.content;
   }
   function assign_nodes(start, end) {
@@ -1665,7 +2350,7 @@
     }
   }
   // @__NO_SIDE_EFFECTS__
-  function template(content, flags) {
+  function from_html(content, flags) {
     var is_fragment = (flags & TEMPLATE_FRAGMENT) !== 0;
     var use_import_node = (flags & TEMPLATE_USE_IMPORT_NODE) !== 0;
     var node;
@@ -1678,7 +2363,7 @@
       }
       var clone = (
         /** @type {TemplateNode} */
-        use_import_node ? document.importNode(node, true) : node.cloneNode(true)
+        use_import_node || is_firefox ? document.importNode(node, true) : node.cloneNode(true)
       );
       if (is_fragment) {
         var start = (
@@ -1713,16 +2398,12 @@
       dom
     );
   }
-  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
-  function is_passive_event(name) {
-    return PASSIVE_EVENTS.includes(name);
-  }
   let should_intro = true;
   function set_text(text, value) {
     var str = value == null ? "" : typeof value === "object" ? value + "" : value;
     if (str !== (text.__t ?? (text.__t = text.nodeValue))) {
       text.__t = str;
-      text.nodeValue = str == null ? "" : str + "";
+      text.nodeValue = str + "";
     }
   }
   function mount(component, options) {
@@ -1751,7 +2432,7 @@
     event_handle(array_from(all_registered_events));
     root_event_handles.add(event_handle);
     var component = void 0;
-    var unmount = effect_root(() => {
+    var unmount = component_root(() => {
       var anchor_node = anchor ?? target.appendChild(create_text());
       branch(() => {
         if (context) {
@@ -1773,7 +2454,7 @@
         }
       });
       return () => {
-        var _a;
+        var _a2;
         for (var event_name of registered_events) {
           target.removeEventListener(event_name, handle_event_propagation);
           var n = (
@@ -1788,9 +2469,8 @@
           }
         }
         root_event_handles.delete(event_handle);
-        mounted_components.delete(component);
         if (anchor_node !== anchor) {
-          (_a = anchor_node.parentNode) == null ? void 0 : _a.removeChild(anchor_node);
+          (_a2 = anchor_node.parentNode) == null ? void 0 : _a2.removeChild(anchor_node);
         }
       };
     });
@@ -1805,15 +2485,20 @@
     var anchor = node;
     var runes = is_runes();
     var active_component_context = component_context;
-    var input;
+    var input = UNINITIALIZED;
     var pending_effect;
     var then_effect;
     var catch_effect;
-    var input_source = (runes ? source : mutable_source)(
+    var input_source = runes ? source(
       /** @type {V} */
       void 0
+    ) : /* @__PURE__ */ mutable_source(
+      /** @type {V} */
+      void 0,
+      false,
+      false
     );
-    var error_source = (runes ? source : mutable_source)(void 0);
+    var error_source = runes ? source(void 0) : /* @__PURE__ */ mutable_source(void 0, false, false);
     var resolved = false;
     function update(state2, restore) {
       resolved = true;
@@ -1822,32 +2507,35 @@
         set_active_reaction(effect2);
         set_component_context(active_component_context);
       }
-      if (state2 === PENDING && pending_fn) {
-        if (pending_effect) resume_effect(pending_effect);
-        else pending_effect = branch(() => pending_fn(anchor));
-      }
-      if (state2 === THEN && then_fn) {
-        if (then_effect) resume_effect(then_effect);
-        else then_effect = branch(() => then_fn(anchor, input_source));
-      }
-      if (state2 === CATCH && catch_fn) {
-        if (catch_effect) resume_effect(catch_effect);
-        else catch_effect = branch(() => catch_fn(anchor, error_source));
-      }
-      if (state2 !== PENDING && pending_effect) {
-        pause_effect(pending_effect, () => pending_effect = null);
-      }
-      if (state2 !== THEN && then_effect) {
-        pause_effect(then_effect, () => then_effect = null);
-      }
-      if (state2 !== CATCH && catch_effect) {
-        pause_effect(catch_effect, () => catch_effect = null);
-      }
-      if (restore) {
-        set_component_context(null);
-        set_active_reaction(null);
-        set_active_effect(null);
-        flush_sync();
+      try {
+        if (state2 === PENDING && pending_fn) {
+          if (pending_effect) resume_effect(pending_effect);
+          else pending_effect = branch(() => pending_fn(anchor));
+        }
+        if (state2 === THEN && then_fn) {
+          if (then_effect) resume_effect(then_effect);
+          else then_effect = branch(() => then_fn(anchor, input_source));
+        }
+        if (state2 === CATCH && catch_fn) {
+          if (catch_effect) resume_effect(catch_effect);
+          else catch_effect = branch(() => catch_fn(anchor, error_source));
+        }
+        if (state2 !== PENDING && pending_effect) {
+          pause_effect(pending_effect, () => pending_effect = null);
+        }
+        if (state2 !== THEN && then_effect) {
+          pause_effect(then_effect, () => then_effect = null);
+        }
+        if (state2 !== CATCH && catch_effect) {
+          pause_effect(catch_effect, () => catch_effect = null);
+        }
+      } finally {
+        if (restore) {
+          set_component_context(null);
+          set_active_reaction(null);
+          set_active_effect(null);
+          flushSync();
+        }
       }
     }
     var effect2 = block(() => {
@@ -1879,47 +2567,61 @@
         internal_set(input_source, input);
         update(THEN, false);
       }
-      return () => input = null;
+      return () => input = UNINITIALIZED;
     });
   }
-  function if_block(node, get_condition, consequent_fn, alternate_fn = null, elseif = false) {
+  function if_block(node, fn, elseif = false) {
     var anchor = node;
     var consequent_effect = null;
     var alternate_effect = null;
-    var condition = null;
+    var condition = UNINITIALIZED;
     var flags = elseif ? EFFECT_TRANSPARENT : 0;
-    block(() => {
-      if (condition === (condition = !!get_condition())) return;
-      if (condition) {
-        if (consequent_effect) {
-          resume_effect(consequent_effect);
-        } else {
-          consequent_effect = branch(() => consequent_fn(anchor));
-        }
-        if (alternate_effect) {
-          pause_effect(alternate_effect, () => {
+    var has_branch = false;
+    const set_branch = (fn2, flag = true) => {
+      has_branch = true;
+      update_branch(flag, fn2);
+    };
+    function commit() {
+      var active = condition ? consequent_effect : alternate_effect;
+      var inactive = condition ? alternate_effect : consequent_effect;
+      if (active) {
+        resume_effect(active);
+      }
+      if (inactive) {
+        pause_effect(inactive, () => {
+          if (condition) {
             alternate_effect = null;
-          });
-        }
-      } else {
-        if (alternate_effect) {
-          resume_effect(alternate_effect);
-        } else if (alternate_fn) {
-          alternate_effect = branch(() => alternate_fn(anchor));
-        }
-        if (consequent_effect) {
-          pause_effect(consequent_effect, () => {
+          } else {
             consequent_effect = null;
-          });
-        }
+          }
+        });
+      }
+    }
+    const update_branch = (new_condition, fn2) => {
+      if (condition === (condition = new_condition)) return;
+      var target = anchor;
+      if (condition) {
+        consequent_effect ?? (consequent_effect = fn2 && branch(() => fn2(target)));
+      } else {
+        alternate_effect ?? (alternate_effect = fn2 && branch(() => fn2(target)));
+      }
+      {
+        commit();
+      }
+    };
+    block(() => {
+      has_branch = false;
+      fn(set_branch);
+      if (!has_branch) {
+        update_branch(null, null);
       }
     }, flags);
   }
-  let current_each_item = null;
   function index(_, i) {
     return i;
   }
-  function pause_effects(state2, items, controlled_anchor, items_map) {
+  function pause_effects(state2, items, controlled_anchor) {
+    var items_map = state2.items;
     var transitions = [];
     var length = items.length;
     for (var i = 0; i < length; i++) {
@@ -1964,19 +2666,27 @@
     }
     var fallback = null;
     var was_empty = false;
-    block(() => {
+    var offscreen_items = /* @__PURE__ */ new Map();
+    var each_array = /* @__PURE__ */ derived_safe_equal(() => {
       var collection = get_collection();
-      var array = is_array(collection) ? collection : collection == null ? [] : array_from(collection);
-      var length = array.length;
-      if (was_empty && length === 0) {
-        return;
-      }
-      was_empty = length === 0;
-      {
-        reconcile(array, state2, anchor, render_fn, flags, get_key);
-      }
+      return is_array(collection) ? collection : collection == null ? [] : array_from(collection);
+    });
+    var array;
+    var each_effect;
+    function commit() {
+      reconcile(
+        each_effect,
+        array,
+        state2,
+        offscreen_items,
+        anchor,
+        render_fn,
+        flags,
+        get_key,
+        get_collection
+      );
       if (fallback_fn !== null) {
-        if (length === 0) {
+        if (array.length === 0) {
           if (fallback) {
             resume_effect(fallback);
           } else {
@@ -1988,11 +2698,26 @@
           });
         }
       }
-      get_collection();
+    }
+    block(() => {
+      each_effect ?? (each_effect = /** @type {Effect} */
+      active_effect);
+      array = get(each_array);
+      var length = array.length;
+      if (was_empty && length === 0) {
+        return;
+      }
+      was_empty = length === 0;
+      {
+        {
+          commit();
+        }
+      }
+      get(each_array);
     });
   }
-  function reconcile(array, state2, anchor, render_fn, flags, get_key) {
-    var _a, _b, _c, _d;
+  function reconcile(each_effect, array, state2, offscreen_items, anchor, render_fn, flags, get_key, get_collection) {
+    var _a2, _b, _c, _d;
     var is_animated = (flags & EACH_IS_ANIMATED) !== 0;
     var should_update = (flags & (EACH_ITEM_REACTIVE | EACH_INDEX_REACTIVE)) !== 0;
     var length = array.length;
@@ -2014,7 +2739,7 @@
         key = get_key(value, i);
         item = items.get(key);
         if (item !== void 0) {
-          (_a = item.a) == null ? void 0 : _a.measure();
+          (_a2 = item.a) == null ? void 0 : _a2.measure();
           (to_animate ?? (to_animate = /* @__PURE__ */ new Set())).add(item);
         }
       }
@@ -2024,21 +2749,33 @@
       key = get_key(value, i);
       item = items.get(key);
       if (item === void 0) {
-        var child_anchor = current ? (
-          /** @type {TemplateNode} */
-          current.e.nodes_start
-        ) : anchor;
-        prev2 = create_item(
-          child_anchor,
-          state2,
-          prev2,
-          prev2 === null ? state2.first : prev2.next,
-          value,
-          key,
-          i,
-          render_fn,
-          flags
-        );
+        var pending = offscreen_items.get(key);
+        if (pending !== void 0) {
+          offscreen_items.delete(key);
+          items.set(key, pending);
+          var next2 = prev2 ? prev2.next : current;
+          link(state2, prev2, pending);
+          link(state2, pending, next2);
+          move(pending, next2, anchor);
+          prev2 = pending;
+        } else {
+          var child_anchor = current ? (
+            /** @type {TemplateNode} */
+            current.e.nodes_start
+          ) : anchor;
+          prev2 = create_item(
+            child_anchor,
+            state2,
+            prev2,
+            prev2 === null ? state2.first : prev2.next,
+            value,
+            key,
+            i,
+            render_fn,
+            flags,
+            get_collection
+          );
+        }
         items.set(key, prev2);
         matched = [];
         stashed = [];
@@ -2124,20 +2861,24 @@
             (_d = to_destroy[i].a) == null ? void 0 : _d.fix();
           }
         }
-        pause_effects(state2, to_destroy, controlled_anchor, items);
+        pause_effects(state2, to_destroy, controlled_anchor);
       }
     }
     if (is_animated) {
       queue_micro_task(() => {
-        var _a2;
+        var _a3;
         if (to_animate === void 0) return;
         for (item of to_animate) {
-          (_a2 = item.a) == null ? void 0 : _a2.apply();
+          (_a3 = item.a) == null ? void 0 : _a3.apply();
         }
       });
     }
-    active_effect.first = state2.first && state2.first.e;
-    active_effect.last = prev2 && prev2.e;
+    each_effect.first = state2.first && state2.first.e;
+    each_effect.last = prev2 && prev2.e;
+    for (var unused of offscreen_items.values()) {
+      destroy_effect(unused.e);
+    }
+    offscreen_items.clear();
   }
   function update_item(item, value, index2, type) {
     if ((type & EACH_ITEM_REACTIVE) !== 0) {
@@ -2153,29 +2894,39 @@
       item.i = index2;
     }
   }
-  function create_item(anchor, state2, prev2, next2, value, key, index2, render_fn, flags) {
-    var previous_each_item = current_each_item;
+  function create_item(anchor, state2, prev2, next2, value, key, index2, render_fn, flags, get_collection, deferred2) {
+    var reactive = (flags & EACH_ITEM_REACTIVE) !== 0;
+    var mutable = (flags & EACH_ITEM_IMMUTABLE) === 0;
+    var v = reactive ? mutable ? /* @__PURE__ */ mutable_source(value, false, false) : source(value) : value;
+    var i = (flags & EACH_INDEX_REACTIVE) === 0 ? index2 : source(index2);
+    var item = {
+      i,
+      v,
+      k: key,
+      a: null,
+      // @ts-expect-error
+      e: null,
+      prev: prev2,
+      next: next2
+    };
     try {
-      var reactive = (flags & EACH_ITEM_REACTIVE) !== 0;
-      var mutable = (flags & EACH_ITEM_IMMUTABLE) === 0;
-      var v = reactive ? mutable ? /* @__PURE__ */ mutable_source(value) : source(value) : value;
-      var i = (flags & EACH_INDEX_REACTIVE) === 0 ? index2 : source(index2);
-      var item = {
-        i,
+      if (anchor === null) {
+        var fragment = document.createDocumentFragment();
+        fragment.append(anchor = create_text());
+      }
+      item.e = branch(() => render_fn(
+        /** @type {Node} */
+        anchor,
         v,
-        k: key,
-        a: null,
-        // @ts-expect-error
-        e: null,
-        prev: prev2,
-        next: next2
-      };
-      current_each_item = item;
-      item.e = branch(() => render_fn(anchor, v, i), hydrating);
+        i,
+        get_collection
+      ), hydrating);
       item.e.prev = prev2 && prev2.e;
       item.e.next = next2 && next2.e;
       if (prev2 === null) {
-        state2.first = item;
+        if (!deferred2) {
+          state2.first = item;
+        }
       } else {
         prev2.next = item;
         prev2.e.next = item.e;
@@ -2186,7 +2937,6 @@
       }
       return item;
     } finally {
-      current_each_item = previous_each_item;
     }
   }
   function move(item, next2, anchor) {
@@ -2202,7 +2952,7 @@
       /** @type {TemplateNode} */
       item.e.nodes_start
     );
-    while (node !== end) {
+    while (node !== null && node !== end) {
       var next_node = (
         /** @type {TemplateNode} */
         /* @__PURE__ */ get_next_sibling(node)
@@ -2223,65 +2973,226 @@
       next2.e.prev = prev2 && prev2.e;
     }
   }
-  function html(node, get_value, svg, mathml, skip_warning) {
+  function html(node, get_value, svg = false, mathml = false, skip_warning = false) {
     var anchor = node;
     var value = "";
-    var effect2;
-    block(() => {
+    template_effect(() => {
+      var effect2 = (
+        /** @type {Effect} */
+        active_effect
+      );
       if (value === (value = get_value() ?? "")) {
         return;
       }
-      if (effect2 !== void 0) {
-        destroy_effect(effect2);
-        effect2 = void 0;
+      if (effect2.nodes_start !== null) {
+        remove_effect_dom(
+          effect2.nodes_start,
+          /** @type {TemplateNode} */
+          effect2.nodes_end
+        );
+        effect2.nodes_start = effect2.nodes_end = null;
       }
       if (value === "") return;
-      effect2 = branch(() => {
-        var html2 = value + "";
-        var node2 = create_fragment_from_html(html2);
-        assign_nodes(
-          /** @type {TemplateNode} */
-          /* @__PURE__ */ get_first_child(node2),
-          /** @type {TemplateNode} */
-          node2.lastChild
-        );
-        {
-          anchor.before(node2);
+      var html2 = value + "";
+      if (svg) html2 = `<svg>${html2}</svg>`;
+      else if (mathml) html2 = `<math>${html2}</math>`;
+      var node2 = create_fragment_from_html(html2);
+      if (svg || mathml) {
+        node2 = /** @type {Element} */
+        /* @__PURE__ */ get_first_child(node2);
+      }
+      assign_nodes(
+        /** @type {TemplateNode} */
+        /* @__PURE__ */ get_first_child(node2),
+        /** @type {TemplateNode} */
+        node2.lastChild
+      );
+      if (svg || mathml) {
+        while (/* @__PURE__ */ get_first_child(node2)) {
+          anchor.before(
+            /** @type {Node} */
+            /* @__PURE__ */ get_first_child(node2)
+          );
         }
-      });
+      } else {
+        anchor.before(node2);
+      }
     });
   }
-  let listening_to_form_reset = false;
-  function add_form_reset_listener() {
-    if (!listening_to_form_reset) {
-      listening_to_form_reset = true;
-      document.addEventListener(
-        "reset",
-        (evt) => {
-          Promise.resolve().then(() => {
-            var _a;
-            if (!evt.defaultPrevented) {
-              for (
-                const e of
-                /**@type {HTMLFormElement} */
-                evt.target.elements
-              ) {
-                (_a = e.__on_r) == null ? void 0 : _a.call(e);
-              }
-            }
-          });
-        },
-        // In the capture phase to guarantee we get noticed of it (no possiblity of stopPropagation)
-        { capture: true }
-      );
+  function r(e) {
+    var t, f, n = "";
+    if ("string" == typeof e || "number" == typeof e) n += e;
+    else if ("object" == typeof e) if (Array.isArray(e)) {
+      var o = e.length;
+      for (t = 0; t < o; t++) e[t] && (f = r(e[t])) && (n && (n += " "), n += f);
+    } else for (f in e) e[f] && (n && (n += " "), n += f);
+    return n;
+  }
+  function clsx$1() {
+    for (var e, t, f = 0, n = "", o = arguments.length; f < o; f++) (e = arguments[f]) && (t = r(e)) && (n && (n += " "), n += t);
+    return n;
+  }
+  function clsx(value) {
+    if (typeof value === "object") {
+      return clsx$1(value);
+    } else {
+      return value ?? "";
     }
   }
-  function set_attribute(element, attribute, value, skip_warning) {
-    var attributes = element.__attributes ?? (element.__attributes = {});
-    if (attributes[attribute] === (attributes[attribute] = value)) return;
-    if (attribute === "style" && "__styles" in element) {
-      element.__styles = {};
+  function to_class(value, hash, directives) {
+    var classname = value == null ? "" : "" + value;
+    if (hash) {
+      classname = classname ? classname + " " + hash : hash;
     }
+    return classname === "" ? null : classname;
+  }
+  function append_styles(styles, important = false) {
+    var separator = important ? " !important;" : ";";
+    var css = "";
+    for (var key in styles) {
+      var value = styles[key];
+      if (value != null && value !== "") {
+        css += " " + key + ": " + value + separator;
+      }
+    }
+    return css;
+  }
+  function to_css_name(name) {
+    if (name[0] !== "-" || name[1] !== "-") {
+      return name.toLowerCase();
+    }
+    return name;
+  }
+  function to_style(value, styles) {
+    if (styles) {
+      var new_style = "";
+      var normal_styles;
+      var important_styles;
+      if (Array.isArray(styles)) {
+        normal_styles = styles[0];
+        important_styles = styles[1];
+      } else {
+        normal_styles = styles;
+      }
+      if (value) {
+        value = String(value).replaceAll(/\s*\/\*.*?\*\/\s*/g, "").trim();
+        var in_str = false;
+        var in_apo = 0;
+        var in_comment = false;
+        var reserved_names = [];
+        if (normal_styles) {
+          reserved_names.push(...Object.keys(normal_styles).map(to_css_name));
+        }
+        if (important_styles) {
+          reserved_names.push(...Object.keys(important_styles).map(to_css_name));
+        }
+        var start_index = 0;
+        var name_index = -1;
+        const len = value.length;
+        for (var i = 0; i < len; i++) {
+          var c = value[i];
+          if (in_comment) {
+            if (c === "/" && value[i - 1] === "*") {
+              in_comment = false;
+            }
+          } else if (in_str) {
+            if (in_str === c) {
+              in_str = false;
+            }
+          } else if (c === "/" && value[i + 1] === "*") {
+            in_comment = true;
+          } else if (c === '"' || c === "'") {
+            in_str = c;
+          } else if (c === "(") {
+            in_apo++;
+          } else if (c === ")") {
+            in_apo--;
+          }
+          if (!in_comment && in_str === false && in_apo === 0) {
+            if (c === ":" && name_index === -1) {
+              name_index = i;
+            } else if (c === ";" || i === len - 1) {
+              if (name_index !== -1) {
+                var name = to_css_name(value.substring(start_index, name_index).trim());
+                if (!reserved_names.includes(name)) {
+                  if (c !== ";") {
+                    i++;
+                  }
+                  var property = value.substring(start_index, i).trim();
+                  new_style += " " + property + ";";
+                }
+              }
+              start_index = i + 1;
+              name_index = -1;
+            }
+          }
+        }
+      }
+      if (normal_styles) {
+        new_style += append_styles(normal_styles);
+      }
+      if (important_styles) {
+        new_style += append_styles(important_styles, true);
+      }
+      new_style = new_style.trim();
+      return new_style === "" ? null : new_style;
+    }
+    return value == null ? null : String(value);
+  }
+  function set_class(dom, is_html, value, hash, prev_classes, next_classes) {
+    var prev2 = dom.__className;
+    if (prev2 !== value || prev2 === void 0) {
+      var next_class_name = to_class(value, hash);
+      {
+        if (next_class_name == null) {
+          dom.removeAttribute("class");
+        } else {
+          dom.className = next_class_name;
+        }
+      }
+      dom.__className = value;
+    }
+    return next_classes;
+  }
+  function update_styles(dom, prev2 = {}, next2, priority) {
+    for (var key in next2) {
+      var value = next2[key];
+      if (prev2[key] !== value) {
+        if (next2[key] == null) {
+          dom.style.removeProperty(key);
+        } else {
+          dom.style.setProperty(key, value, priority);
+        }
+      }
+    }
+  }
+  function set_style(dom, value, prev_styles, next_styles) {
+    var prev2 = dom.__style;
+    if (prev2 !== value) {
+      var next_style_attr = to_style(value, next_styles);
+      {
+        if (next_style_attr == null) {
+          dom.removeAttribute("style");
+        } else {
+          dom.style.cssText = next_style_attr;
+        }
+      }
+      dom.__style = value;
+    } else if (next_styles) {
+      if (Array.isArray(next_styles)) {
+        update_styles(dom, prev_styles == null ? void 0 : prev_styles[0], next_styles[0]);
+        update_styles(dom, prev_styles == null ? void 0 : prev_styles[1], next_styles[1], "important");
+      } else {
+        update_styles(dom, prev_styles, next_styles);
+      }
+    }
+    return next_styles;
+  }
+  const IS_CUSTOM_ELEMENT = Symbol("is custom element");
+  const IS_HTML = Symbol("is html");
+  function set_attribute(element, attribute, value, skip_warning) {
+    var attributes = get_attributes(element);
+    if (attributes[attribute] === (attributes[attribute] = value)) return;
     if (attribute === "loading") {
       element[LOADING_ATTR_SYMBOL] = value;
     }
@@ -2293,13 +3204,23 @@
       element.setAttribute(attribute, value);
     }
   }
+  function get_attributes(element) {
+    return (
+      /** @type {Record<string | symbol, unknown>} **/
+      // @ts-expect-error
+      element.__attributes ?? (element.__attributes = {
+        [IS_CUSTOM_ELEMENT]: element.nodeName.includes("-"),
+        [IS_HTML]: element.namespaceURI === NAMESPACE_HTML
+      })
+    );
+  }
   var setters_cache = /* @__PURE__ */ new Map();
   function get_setters(element) {
     var setters = setters_cache.get(element.nodeName);
     if (setters) return setters;
     setters_cache.set(element.nodeName, setters = []);
     var descriptors;
-    var proto = get_prototype_of(element);
+    var proto = element;
     var element_proto = Element.prototype;
     while (element_proto !== proto) {
       descriptors = get_descriptors(proto);
@@ -2312,44 +3233,20 @@
     }
     return setters;
   }
-  function set_class(dom, value) {
-    var prev_class_name = dom.__className;
-    var next_class_name = to_class(value);
-    if (prev_class_name !== next_class_name || hydrating) {
-      if (value == null) {
-        dom.removeAttribute("class");
-      } else {
-        dom.className = next_class_name;
-      }
-      dom.__className = next_class_name;
-    }
-  }
-  function to_class(value) {
-    return value == null ? "" : value;
-  }
-  function set_style(dom, key, value, important) {
-    var styles = dom.__styles ?? (dom.__styles = {});
-    if (styles[key] === value) {
-      return;
-    }
-    styles[key] = value;
-    if (value == null) {
-      dom.style.removeProperty(key);
-    } else {
-      dom.style.setProperty(key, value, "");
-    }
-  }
-  const request_animation_frame = requestAnimationFrame;
   const now = () => performance.now();
   const raf = {
+    // don't access requestAnimationFrame eagerly outside method
+    // this allows basic testing of user code without JSDOM
+    // bunder will eval and remove ternary when the user's app is built
     tick: (
       /** @param {any} _ */
-      (_) => request_animation_frame(_)
+      (_) => requestAnimationFrame(_)
     ),
     now: () => now(),
     tasks: /* @__PURE__ */ new Set()
   };
-  function run_tasks(now2) {
+  function run_tasks() {
+    const now2 = raf.now();
     raf.tasks.forEach((task) => {
       if (!task.c(now2)) {
         raf.tasks.delete(task);
@@ -2375,7 +3272,9 @@
     };
   }
   function dispatch_event(element, type) {
-    element.dispatchEvent(new CustomEvent(type));
+    without_reactive_context(() => {
+      element.dispatchEvent(new CustomEvent(type));
+    });
   }
   function css_property_to_camelcase(style) {
     if (style === "float") return "cssFloat";
@@ -2408,31 +3307,25 @@
     var direction = is_both ? "both" : is_intro ? "in" : "out";
     var current_options;
     var inert = element.inert;
+    var overflow = element.style.overflow;
     var intro;
     var outro;
     function get_options() {
-      var previous_reaction = active_reaction;
-      var previous_effect = active_effect;
-      set_active_reaction(null);
-      set_active_effect(null);
-      try {
+      return without_reactive_context(() => {
         return current_options ?? (current_options = get_fn()(element, (get_params == null ? void 0 : get_params()) ?? /** @type {P} */
         {}, {
           direction
         }));
-      } finally {
-        set_active_reaction(previous_reaction);
-        set_active_effect(previous_effect);
-      }
+      });
     }
     var transition2 = {
       is_global,
       in() {
-        var _a;
+        var _a2;
         element.inert = inert;
         if (!is_intro) {
           outro == null ? void 0 : outro.abort();
-          (_a = outro == null ? void 0 : outro.reset) == null ? void 0 : _a.call(outro);
+          (_a2 = outro == null ? void 0 : outro.reset) == null ? void 0 : _a2.call(outro);
           return;
         }
         if (!is_outro) {
@@ -2443,6 +3336,7 @@
           dispatch_event(element, "introend");
           intro == null ? void 0 : intro.abort();
           intro = current_options = void 0;
+          element.style.overflow = overflow;
         });
       },
       out(fn) {
@@ -2531,8 +3425,9 @@
       }
     }
     var get_t = () => 1 - t2;
-    var animation = element.animate(keyframes, { duration: delay });
+    var animation = element.animate(keyframes, { duration: delay, fill: "forwards" });
     animation.onfinish = () => {
+      animation.cancel();
       var t1 = (counterpart == null ? void 0 : counterpart.t()) ?? 1 - t2;
       counterpart == null ? void 0 : counterpart.abort();
       var delta = t2 - t1;
@@ -2542,13 +3437,18 @@
       );
       var keyframes2 = [];
       if (duration > 0) {
+        var needs_overflow_hidden = false;
         if (css) {
           var n = Math.ceil(duration / (1e3 / 60));
           for (var i = 0; i <= n; i += 1) {
             var t = t1 + delta * easing(i / n);
-            var styles2 = css(t, 1 - t);
-            keyframes2.push(css_to_keyframe(styles2));
+            var styles2 = css_to_keyframe(css(t, 1 - t));
+            keyframes2.push(styles2);
+            needs_overflow_hidden || (needs_overflow_hidden = styles2.overflow === "hidden");
           }
+        }
+        if (needs_overflow_hidden) {
+          element.style.overflow = "hidden";
         }
         get_t = () => {
           var time = (
@@ -2593,30 +3493,46 @@
       t: () => get_t()
     };
   }
-  function listen_to_event_and_reset_event(element, event2, handler, on_reset = handler) {
-    element.addEventListener(event2, handler);
-    const prev2 = element.__on_r;
-    if (prev2) {
-      element.__on_r = () => {
-        prev2();
-        on_reset();
-      };
-    } else {
-      element.__on_r = on_reset;
-    }
-    add_form_reset_listener();
-  }
   function bind_value(input, get2, set2 = get2) {
     var runes = is_runes();
-    listen_to_event_and_reset_event(input, "input", () => {
-      var value = is_numberlike_input(input) ? to_number(input.value) : input.value;
+    var batches2 = /* @__PURE__ */ new WeakSet();
+    listen_to_event_and_reset_event(input, "input", (is_reset) => {
+      var value = is_reset ? input.defaultValue : input.value;
+      value = is_numberlike_input(input) ? to_number(value) : value;
       set2(value);
+      if (current_batch !== null) {
+        batches2.add(current_batch);
+      }
       if (runes && value !== (value = get2())) {
+        var start = input.selectionStart;
+        var end = input.selectionEnd;
         input.value = value ?? "";
+        if (end !== null) {
+          input.selectionStart = start;
+          input.selectionEnd = Math.min(end, input.value.length);
+        }
       }
     });
+    if (
+      // If we are hydrating and the value has since changed,
+      // then use the updated value from the input instead.
+      // If defaultValue is set, then value == defaultValue
+      // TODO Svelte 6: remove input.value check and set to empty string?
+      untrack(get2) == null && input.value
+    ) {
+      set2(is_numberlike_input(input) ? to_number(input.value) : input.value);
+      if (current_batch !== null) {
+        batches2.add(current_batch);
+      }
+    }
     render_effect(() => {
       var value = get2();
+      if (input === document.activeElement && batches2.has(
+        /** @type {Batch} */
+        current_batch
+      )) {
+        return;
+      }
       if (is_numberlike_input(input) && value === to_number(input.value)) {
         return;
       }
@@ -2663,6 +3579,16 @@
       };
     });
     return element_or_component;
+  }
+  function stopPropagation(fn) {
+    return function(...args) {
+      var event2 = (
+        /** @type {Event} */
+        args[0]
+      );
+      event2.stopPropagation();
+      return fn == null ? void 0 : fn.apply(this, args);
+    };
   }
   function init(immutable = false) {
     const context = (
@@ -2721,6 +3647,17 @@
     }
     props();
   }
+  function bubble_event($$props, event2) {
+    var _a2;
+    var events = (
+      /** @type {Record<string, Function[] | Function>} */
+      (_a2 = $$props.$$events) == null ? void 0 : _a2[event2.type]
+    );
+    var callbacks = is_array(events) ? events.slice() : events == null ? [] : [events];
+    for (var fn of callbacks) {
+      fn.call(this, event2);
+    }
+  }
   let is_store_binding = false;
   function capture_store_binding(fn) {
     var previous_is_store_binding = is_store_binding;
@@ -2731,65 +3668,51 @@
       is_store_binding = previous_is_store_binding;
     }
   }
-  function with_parent_branch(fn) {
-    var effect2 = active_effect;
-    var previous_effect = active_effect;
-    while (effect2 !== null && (effect2.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
-      effect2 = effect2.parent;
-    }
-    try {
-      set_active_effect(effect2);
-      return fn();
-    } finally {
-      set_active_effect(previous_effect);
-    }
-  }
   function prop(props, key, flags, fallback) {
-    var _a;
-    var immutable = (flags & PROPS_IS_IMMUTABLE) !== 0;
-    var runes = (flags & PROPS_IS_RUNES) !== 0;
+    var _a2;
+    var runes = !legacy_mode_flag || (flags & PROPS_IS_RUNES) !== 0;
     var bindable = (flags & PROPS_IS_BINDABLE) !== 0;
     var lazy = (flags & PROPS_IS_LAZY_INITIAL) !== 0;
-    var is_store_sub = false;
-    var prop_value;
-    if (bindable) {
-      [prop_value, is_store_sub] = capture_store_binding(() => (
-        /** @type {V} */
-        props[key]
-      ));
-    } else {
-      prop_value = /** @type {V} */
-      props[key];
-    }
-    var setter = (_a = get_descriptor(props, key)) == null ? void 0 : _a.set;
     var fallback_value = (
       /** @type {V} */
       fallback
     );
     var fallback_dirty = true;
-    var fallback_used = false;
     var get_fallback = () => {
-      fallback_used = true;
       if (fallback_dirty) {
         fallback_dirty = false;
-        if (lazy) {
-          fallback_value = untrack(
-            /** @type {() => V} */
-            fallback
-          );
-        } else {
-          fallback_value = /** @type {V} */
-          fallback;
-        }
+        fallback_value = lazy ? untrack(
+          /** @type {() => V} */
+          fallback
+        ) : (
+          /** @type {V} */
+          fallback
+        );
       }
       return fallback_value;
     };
-    if (prop_value === void 0 && fallback !== void 0) {
-      if (setter && runes) {
-        props_invalid_value();
+    var setter;
+    if (bindable) {
+      var is_entry_props = STATE_SYMBOL in props || LEGACY_PROPS in props;
+      setter = ((_a2 = get_descriptor(props, key)) == null ? void 0 : _a2.set) ?? (is_entry_props && key in props ? (v) => props[key] = v : void 0);
+    }
+    var initial_value;
+    var is_store_sub = false;
+    if (bindable) {
+      [initial_value, is_store_sub] = capture_store_binding(() => (
+        /** @type {V} */
+        props[key]
+      ));
+    } else {
+      initial_value = /** @type {V} */
+      props[key];
+    }
+    if (initial_value === void 0 && fallback !== void 0) {
+      initial_value = get_fallback();
+      if (setter) {
+        if (runes) props_invalid_value();
+        setter(initial_value);
       }
-      prop_value = get_fallback();
-      if (setter) setter(prop_value);
     }
     var getter;
     if (runes) {
@@ -2800,25 +3723,22 @@
         );
         if (value === void 0) return get_fallback();
         fallback_dirty = true;
-        fallback_used = false;
         return value;
       };
     } else {
-      var derived_getter = with_parent_branch(
-        () => (immutable ? derived : derived_safe_equal)(() => (
+      getter = () => {
+        var value = (
           /** @type {V} */
           props[key]
-        ))
-      );
-      derived_getter.f |= LEGACY_DERIVED_PROP;
-      getter = () => {
-        var value = get(derived_getter);
-        if (value !== void 0) fallback_value = /** @type {V} */
-        void 0;
+        );
+        if (value !== void 0) {
+          fallback_value = /** @type {V} */
+          void 0;
+        }
         return value === void 0 ? fallback_value : value;
       };
     }
-    if ((flags & PROPS_IS_UPDATED) === 0) {
+    if (runes && (flags & PROPS_IS_UPDATED) === 0) {
       return getter;
     }
     if (setter) {
@@ -2829,53 +3749,41 @@
             setter(mutation ? getter() : value);
           }
           return value;
-        } else {
-          return getter();
         }
+        return getter();
       };
     }
-    var from_child = false;
-    var was_from_child = false;
-    var inner_current_value = /* @__PURE__ */ mutable_source(prop_value);
-    var current_value = with_parent_branch(
-      () => /* @__PURE__ */ derived(() => {
-        var parent_value = getter();
-        var child_value = get(inner_current_value);
-        var current_derived = (
-          /** @type {Derived} */
-          active_reaction
-        );
-        if (from_child || parent_value === void 0 && (current_derived.f & DESTROYED) !== 0) {
-          from_child = false;
-          was_from_child = true;
-          return child_value;
-        }
-        was_from_child = false;
-        return inner_current_value.v = parent_value;
-      })
+    var overridden = false;
+    var d = ((flags & PROPS_IS_IMMUTABLE) !== 0 ? derived : derived_safe_equal)(() => {
+      overridden = false;
+      return getter();
+    });
+    if (bindable) get(d);
+    var parent_effect = (
+      /** @type {Effect} */
+      active_effect
     );
-    if (!immutable) current_value.equals = safe_equals;
     return function(value, mutation) {
       if (arguments.length > 0) {
-        const new_value = mutation ? get(current_value) : runes && bindable ? proxy(value) : value;
-        if (!current_value.equals(new_value)) {
-          from_child = true;
-          set(inner_current_value, new_value);
-          if (fallback_used && fallback_value !== void 0) {
-            fallback_value = new_value;
-          }
-          untrack(() => get(current_value));
+        const new_value = mutation ? get(d) : runes && bindable ? proxy(value) : value;
+        set(d, new_value);
+        overridden = true;
+        if (fallback_value !== void 0) {
+          fallback_value = new_value;
         }
         return value;
       }
-      return get(current_value);
+      if (is_destroying_effect && overridden || (parent_effect.f & DESTROYED) !== 0) {
+        return d.v;
+      }
+      return get(d);
     };
   }
   function onMount(fn) {
     if (component_context === null) {
       lifecycle_outside_component();
     }
-    if (component_context.l !== null) {
+    if (legacy_mode_flag && component_context.l !== null) {
       init_update_callbacks(component_context).m.push(fn);
     } else {
       user_effect(() => {
@@ -2895,14 +3803,16 @@
     return l.u ?? (l.u = { a: [], b: [], m: [] });
   }
   const PUBLIC_VERSION = "5";
-  if (typeof window !== "undefined")
-    (window.__svelte || (window.__svelte = { v: /* @__PURE__ */ new Set() })).v.add(PUBLIC_VERSION);
-  var root$5 = /* @__PURE__ */ template(`<div class="loadership_ZOJAQ svelte-i1jlc0"><div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div></div>`);
+  if (typeof window !== "undefined") {
+    ((_a = window.__svelte ?? (window.__svelte = {})).v ?? (_a.v = /* @__PURE__ */ new Set())).add(PUBLIC_VERSION);
+  }
+  enable_legacy_mode_flag();
+  var root$6 = /* @__PURE__ */ from_html(`<div class="loadership_ZOJAQ svelte-i1jlc0"><div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div> <div class="svelte-i1jlc0"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$5();
+    var div = root$6();
     append($$anchor, div);
   }
-  var root_1$1 = /* @__PURE__ */ template(`<img class="fi svelte-7lhsry">`);
+  var root_1$2 = /* @__PURE__ */ from_html(`<img class="fi svelte-7lhsry"/>`);
   function CountryFlag($$anchor, $$props) {
     const countryCodes = {
       Afghanistan: "af",
@@ -3108,12 +4018,22 @@
     const countryCode = countryCodes[$$props.countryName];
     var fragment = comment();
     var node = first_child(fragment);
-    if_block(node, () => countryCode, ($$anchor2) => {
-      var img = root_1$1();
-      template_effect(() => set_attribute(img, "src", `https://purecatamphetamine.github.io/country-flag-icons/3x2/${countryCode.toUpperCase() ?? ""}.svg`));
-      template_effect(() => set_attribute(img, "alt", $$props.countryName));
-      append($$anchor2, img);
-    });
+    {
+      var consequent = ($$anchor2) => {
+        var img = root_1$2();
+        template_effect(
+          ($0) => {
+            set_attribute(img, "alt", $$props.countryName);
+            set_attribute(img, "src", `https://purecatamphetamine.github.io/country-flag-icons/3x2/${$0 ?? ""}.svg`);
+          },
+          [() => countryCode.toUpperCase()]
+        );
+        append($$anchor2, img);
+      };
+      if_block(node, ($$render) => {
+        if (countryCode) $$render(consequent);
+      });
+    }
     append($$anchor, fragment);
   }
   const leftKey = "geometa:containerStyleLeft";
@@ -3200,20 +4120,20 @@
     set(lensX, event2.clientX - rect.left);
     set(lensY, event2.clientY - rect.top);
   }
-  var root_4 = /* @__PURE__ */ template(`<div class="lens svelte-fofh7f"></div>`);
-  var root_3$1 = /* @__PURE__ */ template(`<div class="image-wrapper svelte-fofh7f" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-fofh7f"> <!></div>`);
-  var root_6$1 = /* @__PURE__ */ template(`<button></button>`);
-  var root_5$1 = /* @__PURE__ */ template(`<div class="controls"><button class="click-area prev-area svelte-fofh7f" type="button" aria-label="Previous image"><span class="prev svelte-fofh7f">&#10094;</span></button> <button class="click-area next-area svelte-fofh7f" type="button" aria-label="Next image"><span class="next svelte-fofh7f">&#10095;</span></button></div> <div class="indicators svelte-fofh7f"></div>`, 1);
-  var root$4 = /* @__PURE__ */ template(`<div class="carousel svelte-fofh7f"><!> <!></div>`);
+  var root_4 = /* @__PURE__ */ from_html(`<div class="lens svelte-fofh7f"></div>`);
+  var root_3$1 = /* @__PURE__ */ from_html(`<div class="image-wrapper svelte-fofh7f" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-fofh7f"/> <!></div>`);
+  var root_6$1 = /* @__PURE__ */ from_html(`<button></button>`);
+  var root_5$1 = /* @__PURE__ */ from_html(`<div class="controls"><button class="click-area prev-area svelte-fofh7f" type="button" aria-label="Previous image"><span class="prev svelte-fofh7f">&#10094;</span></button> <button class="click-area next-area svelte-fofh7f" type="button" aria-label="Next image"><span class="next svelte-fofh7f">&#10095;</span></button></div> <div class="indicators svelte-fofh7f"></div>`, 1);
+  var root$5 = /* @__PURE__ */ from_html(`<div class="carousel svelte-fofh7f"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
-    let currentIndex = mutable_state(0);
-    let containerRef = mutable_state(null);
-    let imageRef = mutable_state(null);
-    let isZoomed = mutable_state(false);
-    let lensX = mutable_state(0);
-    let lensY = mutable_state(0);
+    let currentIndex = /* @__PURE__ */ mutable_source(0);
+    let containerRef = /* @__PURE__ */ mutable_source(null);
+    let imageRef = /* @__PURE__ */ mutable_source(null);
+    let isZoomed = /* @__PURE__ */ mutable_source(false);
+    let lensX = /* @__PURE__ */ mutable_source(0);
+    let lensY = /* @__PURE__ */ mutable_source(0);
     let lensSize = 150;
     let scale = 2;
     function handleMouseEnter() {
@@ -3223,64 +4143,84 @@
       set(isZoomed, false);
     }
     init();
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
-    if_block(node, () => images().length, ($$anchor2) => {
-      var fragment = comment();
-      var node_1 = first_child(fragment);
-      each(node_1, 1, images, index, ($$anchor3, image, index2) => {
-        var fragment_1 = comment();
-        var node_2 = first_child(fragment_1);
-        if_block(node_2, () => index2 === get(currentIndex), ($$anchor4) => {
-          var div_1 = root_3$1();
-          bind_this(div_1, ($$value) => set(containerRef, $$value), () => get(containerRef));
-          div_1.__mousemove = [handleMouseMove, containerRef, lensX, lensY];
-          var img = child(div_1);
-          bind_this(img, ($$value) => set(imageRef, $$value), () => get(imageRef));
-          set_attribute(img, "alt", `Image ${index2 + 1}`);
-          var node_3 = sibling(img, 2);
-          if_block(node_3, () => get(isZoomed) && get(imageRef), ($$anchor5) => {
-            var div_2 = root_4();
-            template_effect(() => set_attribute(div_2, "style", `
+    {
+      var consequent_2 = ($$anchor2) => {
+        var fragment = comment();
+        var node_1 = first_child(fragment);
+        each(node_1, 1, images, index, ($$anchor3, image, index2) => {
+          var fragment_1 = comment();
+          var node_2 = first_child(fragment_1);
+          {
+            var consequent_1 = ($$anchor4) => {
+              var div_1 = root_3$1();
+              div_1.__mousemove = [handleMouseMove, containerRef, lensX, lensY];
+              var img = child(div_1);
+              set_attribute(img, "alt", `Image ${index2 + 1}`);
+              bind_this(img, ($$value) => set(imageRef, $$value), () => get(imageRef));
+              var node_3 = sibling(img, 2);
+              {
+                var consequent = ($$anchor5) => {
+                  var div_2 = root_4();
+                  template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
                 left: ${get(lensX) - lensSize / 2}px;
-                width: ${lensSize}px;
-                height: ${lensSize}px;
+                width: 150px;
+                height: 150px;
                 background-image: url(${get(image) ?? ""});
                 background-repeat: no-repeat;
-                background-size: ${get(imageRef).width * scale}px ${get(imageRef).height * scale}px;
+                background-size: ${(get(imageRef), untrack(() => get(imageRef).width * scale)) ?? ""}px ${(get(imageRef), untrack(() => get(imageRef).height * scale)) ?? ""}px;
                 background-position: ${-(get(lensX) * scale - lensSize / 2)}px ${-(get(lensY) * scale - lensSize / 2)}px;
               `));
-            append($$anchor5, div_2);
-          });
-          template_effect(() => set_attribute(img, "src", get(image)));
-          event("mouseenter", div_1, handleMouseEnter);
-          event("mouseleave", div_1, handleMouseLeave);
-          append($$anchor4, div_1);
+                  append($$anchor5, div_2);
+                };
+                if_block(node_3, ($$render) => {
+                  if (get(isZoomed) && get(imageRef)) $$render(consequent);
+                });
+              }
+              bind_this(div_1, ($$value) => set(containerRef, $$value), () => get(containerRef));
+              template_effect(() => set_attribute(img, "src", get(image)));
+              event("mouseenter", div_1, handleMouseEnter);
+              event("mouseleave", div_1, handleMouseLeave);
+              append($$anchor4, div_1);
+            };
+            if_block(node_2, ($$render) => {
+              if (index2 === get(currentIndex)) $$render(consequent_1);
+            });
+          }
+          append($$anchor3, fragment_1);
         });
-        append($$anchor3, fragment_1);
+        append($$anchor2, fragment);
+      };
+      if_block(node, ($$render) => {
+        if (deep_read_state(images()), untrack(() => images().length)) $$render(consequent_2);
       });
-      append($$anchor2, fragment);
-    });
+    }
     var node_4 = sibling(node, 2);
-    if_block(node_4, () => images().length > 1, ($$anchor2) => {
-      var fragment_2 = root_5$1();
-      var div_3 = first_child(fragment_2);
-      var button = child(div_3);
-      button.__click = [prev, currentIndex, images];
-      var button_1 = sibling(button, 2);
-      button_1.__click = [next, currentIndex, images];
-      var div_4 = sibling(div_3, 2);
-      each(div_4, 5, images, index, ($$anchor3, _, index2) => {
-        var button_2 = root_6$1();
-        set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
-        button_2.__click = () => set(currentIndex, index2);
-        template_effect(() => set_class(button_2, `indicator ${(index2 === get(currentIndex) ? "active" : "") ?? ""} svelte-fofh7f`));
-        append($$anchor3, button_2);
+    {
+      var consequent_3 = ($$anchor2) => {
+        var fragment_2 = root_5$1();
+        var div_3 = first_child(fragment_2);
+        var button = child(div_3);
+        button.__click = [prev, currentIndex, images];
+        var button_1 = sibling(button, 2);
+        button_1.__click = [next, currentIndex, images];
+        var div_4 = sibling(div_3, 2);
+        each(div_4, 5, images, index, ($$anchor3, _, index2) => {
+          var button_2 = root_6$1();
+          set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
+          button_2.__click = () => set(currentIndex, index2);
+          template_effect(() => set_class(button_2, 1, `indicator ${index2 === get(currentIndex) ? "active" : ""}`, "svelte-fofh7f"));
+          append($$anchor3, button_2);
+        });
+        append($$anchor2, fragment_2);
+      };
+      if_block(node_4, ($$render) => {
+        if (deep_read_state(images()), untrack(() => images().length > 1)) $$render(consequent_3);
       });
-      append($$anchor2, fragment_2);
-    });
+    }
     append($$anchor, div);
     pop();
   }
@@ -3388,32 +4328,32 @@
   }
   var on_click = (__3, announcement, lastDismissedTimestamp) => {
     markAnnouncementAsDismissed(get(announcement).timestamp);
-    set(lastDismissedTimestamp, proxy(get(announcement).timestamp));
+    set(lastDismissedTimestamp, get(announcement).timestamp, true);
   };
-  var root_2 = /* @__PURE__ */ template(`<div class="announcement svelte-a3mhc8"><div class="svelte-a3mhc8"><!></div> <button class="vote-close-btn svelte-a3mhc8" aria-label="Dismiss announcement">Dismiss</button></div>`);
-  var root_3 = /* @__PURE__ */ template(`<p class="svelte-a3mhc8"> </p>`);
-  var root_6 = /* @__PURE__ */ template(`<p class="geometa-footer svelte-a3mhc8"><!></p>`);
-  var root_7 = /* @__PURE__ */ template(`<hr class="svelte-a3mhc8"> <!>`, 1);
-  var root_5 = /* @__PURE__ */ template(`<p class="svelte-a3mhc8"><!> <strong class="svelte-a3mhc8"> </strong> </p> <div class="geometa-note svelte-a3mhc8"><!></div> <!> <!>`, 1);
-  var root_9 = /* @__PURE__ */ template(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><p class="svelte-a3mhc8">You are about to open this site in a new tab:</p> <p class="modal-url svelte-a3mhc8"> </p> <div class="modal-buttons svelte-a3mhc8"><button class="proceed-btn svelte-a3mhc8">Continue</button> <button class="close-btn svelte-a3mhc8">Cancel</button></div></div></div>`);
-  var root_11 = /* @__PURE__ */ template(`<p class="outdated svelte-a3mhc8"><strong class="svelte-a3mhc8"> </strong></p>`);
-  var root_10 = /* @__PURE__ */ template(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><div class="help-message svelte-a3mhc8"><!> <p class="svelte-a3mhc8">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-a3mhc8"><li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere on your
+  var root_2 = /* @__PURE__ */ from_html(`<div class="announcement svelte-a3mhc8"><div class="svelte-a3mhc8"><!></div> <button class="vote-close-btn svelte-a3mhc8" aria-label="Dismiss announcement">Dismiss</button></div>`);
+  var root_3 = /* @__PURE__ */ from_html(`<p class="svelte-a3mhc8"> </p>`);
+  var root_6 = /* @__PURE__ */ from_html(`<p class="geometa-footer svelte-a3mhc8"><!></p>`);
+  var root_7 = /* @__PURE__ */ from_html(`<hr class="svelte-a3mhc8"/> <!>`, 1);
+  var root_5 = /* @__PURE__ */ from_html(`<p class="svelte-a3mhc8"><!> <strong class="svelte-a3mhc8"> </strong> </p> <div class="geometa-note svelte-a3mhc8"><!></div> <!> <!>`, 1);
+  var root_9 = /* @__PURE__ */ from_html(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><p class="svelte-a3mhc8">You are about to open this site in a new tab:</p> <p class="modal-url svelte-a3mhc8"> </p> <div class="modal-buttons svelte-a3mhc8"><button class="proceed-btn svelte-a3mhc8">Continue</button> <button class="close-btn svelte-a3mhc8">Cancel</button></div></div></div>`);
+  var root_11 = /* @__PURE__ */ from_html(`<p class="outdated svelte-a3mhc8"><strong class="svelte-a3mhc8"> </strong></p>`);
+  var root_10 = /* @__PURE__ */ from_html(`<div class="modal-backdrop svelte-a3mhc8"><div class="modal svelte-a3mhc8"><div class="help-message svelte-a3mhc8"><!> <p class="svelte-a3mhc8">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-a3mhc8"><li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere on your
               screen.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">View Map meta list:</strong> Click the list icon to see all the metas included in the map you
               are currently playing.</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Join the Community:</strong> Click the Discord icon to share feedback, suggest improvements, or
               just say hi!</li> <li class="svelte-a3mhc8"><strong class="svelte-a3mhc8">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-a3mhc8">Close</button></div></div>`);
-  var root$3 = /* @__PURE__ */ template(`<div class="geometa-container svelte-a3mhc8"><!> <div class="flex header svelte-a3mhc8"><h2 class="svelte-a3mhc8">Learnable Meta</h2> <div class="icons svelte-a3mhc8"><a target="_blank" aria-label="List of map metas" class="svelte-a3mhc8"><span class="skill-icons--list svelte-a3mhc8"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-a3mhc8"><span class="flat-color-icons--globe svelte-a3mhc8"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-a3mhc8"><span class="skill-icons--discord svelte-a3mhc8"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-a3mhc8"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root$4 = /* @__PURE__ */ from_html(`<div class="geometa-container svelte-a3mhc8"><!> <div class="flex header svelte-a3mhc8"><h2 class="svelte-a3mhc8">Learnable Meta</h2> <div class="icons svelte-a3mhc8"><a target="_blank" aria-label="List of map metas" class="svelte-a3mhc8"><span class="skill-icons--list svelte-a3mhc8"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-a3mhc8"><span class="flat-color-icons--globe svelte-a3mhc8"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-a3mhc8"><span class="skill-icons--discord svelte-a3mhc8"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-a3mhc8"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
-    let geoInfo = state(null);
-    let error = state(null);
+    let geoInfo = /* @__PURE__ */ state(null);
+    let error = /* @__PURE__ */ state(null);
     let container;
     let header;
     onMount(() => {
-      var _a;
+      var _a2;
       const cacheKey = `${$$props.mapId}_${$$props.panoId}`;
-      const cachedData = (_a = window.geometaMetaCache) == null ? void 0 : _a.get(cacheKey);
+      const cachedData = (_a2 = window.geometaMetaCache) == null ? void 0 : _a2.get(cacheKey);
       if (cachedData) {
-        set(geoInfo, proxy(cachedData));
+        set(geoInfo, cachedData, true);
       } else {
         const urlParams = new URLSearchParams({
           panoId: $$props.panoId,
@@ -3429,7 +4369,7 @@
             if (response.status === 200) {
               try {
                 const data = JSON.parse(response.responseText);
-                set(geoInfo, proxy(data));
+                set(geoInfo, data, true);
                 if (!window.geometaMetaCache) {
                   window.geometaMetaCache = /* @__PURE__ */ new Map();
                 }
@@ -3469,18 +4409,18 @@
     });
     function confirmNavigation(event2) {
       event2.preventDefault();
-      set(currentUrl, proxy(event2.currentTarget.href));
+      set(currentUrl, event2.currentTarget.href, true);
       set(showModal, true);
     }
-    let showModal = state(false);
-    let currentUrl = state("");
-    let showHelpPopup = state(false);
-    let helpClass = state("question-mark-icon");
+    let showModal = /* @__PURE__ */ state(false);
+    let currentUrl = /* @__PURE__ */ state("");
+    let showHelpPopup = /* @__PURE__ */ state(false);
+    let helpClass = /* @__PURE__ */ state("question-mark-icon");
     function shouldBlink() {
       return !wasHelpMessageRead() || checkIfOutdated();
     }
     function updateHelpClass() {
-      set(helpClass, proxy(shouldBlink() ? "question-mark-icon blink" : "question-mark-icon"));
+      set(helpClass, shouldBlink() ? "question-mark-icon blink" : "question-mark-icon", true);
     }
     updateHelpClass();
     user_effect(() => {
@@ -3492,52 +4432,50 @@
         });
       }
     });
-    let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$3();
-    bind_this(div, ($$value) => container = $$value, () => container);
+    let lastDismissedTimestamp = /* @__PURE__ */ state(proxy(getLastDismissedAnnouncementTimestamp()));
+    var div = root$4();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
       var node_1 = first_child(fragment);
-      if_block(node_1, () => $$props.roundNumber >= 4 && get(announcement) && (!get(lastDismissedTimestamp) || get(announcement).timestamp > get(lastDismissedTimestamp)), ($$anchor3) => {
-        var div_1 = root_2();
-        var div_2 = child(div_1);
-        var node_2 = child(div_2);
-        html(node_2, () => get(announcement).htmlMessage);
-        var button = sibling(div_2, 2);
-        button.__click = [
-          on_click,
-          announcement,
-          lastDismissedTimestamp
-        ];
-        append($$anchor3, div_1);
-      });
+      {
+        var consequent = ($$anchor3) => {
+          var div_1 = root_2();
+          var div_2 = child(div_1);
+          var node_2 = child(div_2);
+          html(node_2, () => get(announcement).htmlMessage);
+          reset(div_2);
+          var button = sibling(div_2, 2);
+          button.__click = [on_click, announcement, lastDismissedTimestamp];
+          reset(div_1);
+          append($$anchor3, div_1);
+        };
+        if_block(node_1, ($$render) => {
+          if ($$props.roundNumber >= 4 && get(announcement) && (!get(lastDismissedTimestamp) || get(announcement).timestamp > get(lastDismissedTimestamp))) $$render(consequent);
+        });
+      }
       append($$anchor2, fragment);
     });
     var div_3 = sibling(node, 2);
-    bind_this(div_3, ($$value) => header = $$value, () => header);
     var div_4 = sibling(child(div_3), 2);
     var a = child(div_4);
     var button_1 = sibling(a, 6);
     button_1.__click = [togglePopup, showHelpPopup, updateHelpClass];
     var span = child(button_1);
+    bind_this(div_3, ($$value) => header = $$value, () => header);
     var node_3 = sibling(div_3, 2);
-    if_block(
-      node_3,
-      () => get(error),
-      ($$anchor2) => {
+    {
+      var consequent_1 = ($$anchor2) => {
         var p = root_3();
         var text = child(p);
         template_effect(() => set_text(text, `Error: ${get(error) ?? ""}`));
         append($$anchor2, p);
-      },
-      ($$anchor2) => {
+      };
+      var alternate_1 = ($$anchor2) => {
         var fragment_1 = comment();
         var node_4 = first_child(fragment_1);
-        if_block(
-          node_4,
-          () => get(geoInfo),
-          ($$anchor3) => {
+        {
+          var consequent_4 = ($$anchor3) => {
             var fragment_2 = root_5();
             var p_1 = first_child(fragment_2);
             var node_5 = child(p_1);
@@ -3553,77 +4491,254 @@
             var node_6 = child(div_5);
             html(node_6, () => get(geoInfo).note);
             var node_7 = sibling(div_5, 2);
-            if_block(node_7, () => get(geoInfo).footer, ($$anchor4) => {
-              var p_2 = root_6();
-              var node_8 = child(p_2);
-              html(node_8, () => get(geoInfo).footer);
-              append($$anchor4, p_2);
-            });
-            var node_9 = sibling(node_7, 2);
-            if_block(node_9, () => get(geoInfo).images && get(geoInfo).images.length, ($$anchor4) => {
-              var fragment_3 = root_7();
-              var node_10 = sibling(first_child(fragment_3), 2);
-              Carousel(node_10, {
-                get images() {
-                  return get(geoInfo).images;
-                }
+            {
+              var consequent_2 = ($$anchor4) => {
+                var p_2 = root_6();
+                var node_8 = child(p_2);
+                html(node_8, () => get(geoInfo).footer);
+                append($$anchor4, p_2);
+              };
+              if_block(node_7, ($$render) => {
+                if (get(geoInfo).footer) $$render(consequent_2);
               });
-              append($$anchor4, fragment_3);
-            });
+            }
+            var node_9 = sibling(node_7, 2);
+            {
+              var consequent_3 = ($$anchor4) => {
+                var fragment_3 = root_7();
+                var node_10 = sibling(first_child(fragment_3), 2);
+                Carousel(node_10, {
+                  get images() {
+                    return get(geoInfo).images;
+                  }
+                });
+                append($$anchor4, fragment_3);
+              };
+              if_block(node_9, ($$render) => {
+                if (get(geoInfo).images && get(geoInfo).images.length) $$render(consequent_3);
+              });
+            }
             template_effect(() => {
               set_text(text_1, get(geoInfo).country);
               set_text(text_2, ` - ${get(geoInfo).metaName ?? ""}`);
             });
             append($$anchor3, fragment_2);
-          },
-          ($$anchor3) => {
+          };
+          var alternate = ($$anchor3) => {
             Spinner($$anchor3);
-          },
-          true
-        );
+          };
+          if_block(
+            node_4,
+            ($$render) => {
+              if (get(geoInfo)) $$render(consequent_4);
+              else $$render(alternate, false);
+            },
+            true
+          );
+        }
         append($$anchor2, fragment_1);
-      }
-    );
-    var node_11 = sibling(node_3, 2);
-    if_block(node_11, () => get(showModal), ($$anchor2) => {
-      var div_6 = root_9();
-      var div_7 = child(div_6);
-      var p_3 = sibling(child(div_7), 2);
-      var text_3 = child(p_3);
-      var div_8 = sibling(p_3, 2);
-      var button_2 = child(div_8);
-      button_2.__click = [proceed, showModal, currentUrl];
-      var button_3 = sibling(button_2, 2);
-      button_3.__click = [cancel, showModal];
-      template_effect(() => set_text(text_3, get(currentUrl)));
-      append($$anchor2, div_6);
-    });
-    var node_12 = sibling(node_11, 2);
-    if_block(node_12, () => get(showHelpPopup), ($$anchor2) => {
-      var div_9 = root_10();
-      var div_10 = child(div_9);
-      var div_11 = child(div_10);
-      var node_13 = child(div_11);
-      if_block(node_13, checkIfOutdated, ($$anchor3) => {
-        var p_4 = root_11();
-        var strong_1 = child(p_4);
-        var text_4 = child(strong_1);
-        template_effect(() => set_text(text_4, `Your script version is out of date - please install the latest
-              version (${getLatestVersionInfo() ?? ""})!`));
-        append($$anchor3, p_4);
+      };
+      if_block(node_3, ($$render) => {
+        if (get(error)) $$render(consequent_1);
+        else $$render(alternate_1, false);
       });
-      var button_4 = sibling(div_11, 2);
-      button_4.__click = [togglePopup, showHelpPopup, updateHelpClass];
-      append($$anchor2, div_9);
-    });
+    }
+    var node_11 = sibling(node_3, 2);
+    {
+      var consequent_5 = ($$anchor2) => {
+        var div_6 = root_9();
+        var div_7 = child(div_6);
+        var p_3 = sibling(child(div_7), 2);
+        var text_3 = child(p_3);
+        var div_8 = sibling(p_3, 2);
+        var button_2 = child(div_8);
+        button_2.__click = [proceed, showModal, currentUrl];
+        var button_3 = sibling(button_2, 2);
+        button_3.__click = [cancel, showModal];
+        template_effect(() => set_text(text_3, get(currentUrl)));
+        append($$anchor2, div_6);
+      };
+      if_block(node_11, ($$render) => {
+        if (get(showModal)) $$render(consequent_5);
+      });
+    }
+    var node_12 = sibling(node_11, 2);
+    {
+      var consequent_7 = ($$anchor2) => {
+        var div_9 = root_10();
+        var div_10 = child(div_9);
+        var div_11 = child(div_10);
+        var node_13 = child(div_11);
+        {
+          var consequent_6 = ($$anchor3) => {
+            var p_4 = root_11();
+            var strong_1 = child(p_4);
+            var text_4 = child(strong_1);
+            template_effect(
+              ($0) => set_text(text_4, `Your script version is out of date - please install the latest
+              version (${$0 ?? ""})!`),
+              [getLatestVersionInfo]
+            );
+            append($$anchor3, p_4);
+          };
+          if_block(node_13, ($$render) => {
+            if (checkIfOutdated()) $$render(consequent_6);
+          });
+        }
+        var button_4 = sibling(div_11, 2);
+        button_4.__click = [togglePopup, showHelpPopup, updateHelpClass];
+        append($$anchor2, div_9);
+      };
+      if_block(node_12, ($$render) => {
+        if (get(showHelpPopup)) $$render(consequent_7);
+      });
+    }
+    bind_this(div, ($$value) => container = $$value, () => container);
     template_effect(() => {
       set_attribute(a, "href", "https://learnablemeta.com/maps/" + $$props.mapId);
-      set_class(span, `${get(helpClass) ?? ""} svelte-a3mhc8`);
+      set_class(span, 1, clsx(get(helpClass)), "svelte-a3mhc8");
     });
     append($$anchor, div);
     pop();
   }
   delegate(["click"]);
+  var root_1$1 = /* @__PURE__ */ from_html(`<div class="error svelte-rfbclr"> </div>`);
+  var root$3 = /* @__PURE__ */ from_html(`<div class="hint-panel svelte-rfbclr"><header class="svelte-rfbclr"><strong>Hint</strong> <button class="close svelte-rfbclr">×</button></header> <div><label>Country <input class="svelte-rfbclr"/></label></div> <div><label>Meta type <input class="svelte-rfbclr"/></label></div> <div><label>Description <textarea rows="2" class="svelte-rfbclr"></textarea></label></div> <!> <button>Submit</button></div>`);
+  function HintPanel($$anchor, $$props) {
+    push($$props, false);
+    const SUPABASE_URL = "https://kacuunztbvznzhfsyfgp.supabase.co";
+    const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImthY3V1bnp0YnZ6bnpoZnN5ZmdwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQxODY0NjEsImV4cCI6MjA2OTc2MjQ2MX0.VsC1HLOG413lXABUn4Sfv9c_arN06IxH9EXIdn-fzj4";
+    let country = /* @__PURE__ */ mutable_source("");
+    let meta_type = /* @__PURE__ */ mutable_source("");
+    let description = /* @__PURE__ */ mutable_source("");
+    let image_url = "";
+    let error = /* @__PURE__ */ mutable_source("");
+    const metaTypes = [
+      "bollard",
+      "car",
+      "sign",
+      "language",
+      "generation",
+      "antenna",
+      "coverage"
+    ];
+    onMount(() => {
+      detectCountry();
+      detectMetaType();
+      detectImage();
+    });
+    function detectCountry() {
+      var _a2;
+      const flag = document.querySelector('[class*="result-layout_flag"] img, img.flag');
+      const alt = (_a2 = flag == null ? void 0 : flag.getAttribute("alt")) == null ? void 0 : _a2.trim();
+      if (alt) {
+        set(country, alt);
+      }
+    }
+    function detectMetaType() {
+      var _a2, _b;
+      const note = ((_b = (_a2 = document.querySelector(".geometa-note")) == null ? void 0 : _a2.textContent) == null ? void 0 : _b.toLowerCase()) || "";
+      const found = metaTypes.find((t) => note.includes(t));
+      if (found) {
+        set(meta_type, found);
+      }
+    }
+    function detectImage() {
+      const img = document.querySelector('[class*="result-layout_root"] img.responsive-image');
+      image_url = (img == null ? void 0 : img.getAttribute("src")) || "";
+    }
+    function gmRequest(options) {
+      return new Promise((resolve, reject) => {
+        _GM_xmlhttpRequest({ ...options, onload: resolve, onerror: reject });
+      });
+    }
+    async function submit() {
+      try {
+        detectImage();
+        const res = await gmRequest({
+          method: "POST",
+          url: `${SUPABASE_URL}/rest/v1/hints`,
+          headers: {
+            apikey: SUPABASE_KEY,
+            Authorization: `Bearer ${SUPABASE_KEY}`,
+            "Content-Type": "application/json"
+          },
+          data: JSON.stringify({
+            country: get(country),
+            meta_type: get(meta_type),
+            description: get(description),
+            image_url
+          })
+        });
+        if (res.status >= 200 && res.status < 300) {
+          set(country, "");
+          set(meta_type, "");
+          set(description, "");
+          image_url = "";
+          set(error, "");
+        } else {
+          set(error, "Failed to submit");
+        }
+      } catch (e) {
+        set(error, "Failed to submit");
+      }
+    }
+    init();
+    var div = root$3();
+    var header = child(div);
+    var button = sibling(child(header), 2);
+    var div_1 = sibling(header, 2);
+    var label = child(div_1);
+    var input = sibling(child(label));
+    var div_2 = sibling(div_1, 2);
+    var label_1 = child(div_2);
+    var input_1 = sibling(child(label_1));
+    var div_3 = sibling(div_2, 2);
+    var label_2 = child(div_3);
+    var textarea = sibling(child(label_2));
+    var node = sibling(div_3, 2);
+    {
+      var consequent = ($$anchor2) => {
+        var div_4 = root_1$1();
+        var text = child(div_4);
+        template_effect(() => set_text(text, get(error)));
+        append($$anchor2, div_4);
+      };
+      if_block(node, ($$render) => {
+        if (get(error)) $$render(consequent);
+      });
+    }
+    var button_1 = sibling(node, 2);
+    event("click", button, () => {
+      var _a2;
+      return (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
+    });
+    bind_value(input, () => get(country), ($$value) => set(country, $$value));
+    event("keydown", input, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    bind_value(input_1, () => get(meta_type), ($$value) => set(meta_type, $$value));
+    event("keydown", input_1, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    bind_value(textarea, () => get(description), ($$value) => set(description, $$value));
+    event("keydown", textarea, stopPropagation(function($$arg) {
+      bubble_event.call(this, $$props, $$arg);
+    }));
+    event("click", button_1, submit);
+    append($$anchor, div);
+    pop();
+  }
+  function mountHintPanel(container) {
+    const existing = document.getElementById("geometa-hints");
+    if (existing) {
+      existing.remove();
+    }
+    const element = document.createElement("div");
+    element.id = "geometa-hints";
+    container.appendChild(element);
+    mount(HintPanel, { target: element });
+  }
   const GeoGuessrEventFramework = _unsafeWindow.GeoGuessrEventFramework;
   let currentObserver = null;
   let currentPinObserver = null;
@@ -3639,15 +4754,16 @@
         await getMapInfo(event2.detail.map.id, true);
       });
       GeoGuessrEventFramework.events.addEventListener("round_end", async (event2) => {
-        var _a;
-        (_a = document.getElementById("geometa-summary")) == null ? void 0 : _a.remove();
+        var _a2, _b;
+        (_a2 = document.getElementById("geometa-summary")) == null ? void 0 : _a2.remove();
+        (_b = document.getElementById("geometa-hints")) == null ? void 0 : _b.remove();
         const mapInfo = await getMapInfo(event2.detail.map.id, false);
         if (!mapInfo.mapFound) {
           logInfo("not supported map - skip");
           return;
         }
         logInfo("waiting for the result view to render");
-        waitForElement('div[data-qa="result-view-top"]').then((container) => {
+        waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
           if (!container) {
             return;
           }
@@ -3667,6 +4783,7 @@
               source: window.location.href.includes("challenge") ? "challenge" : "map"
             }
           });
+          mountHintPanel(container);
         });
       });
       GeoGuessrEventFramework.events.addEventListener("game_end", async (event2) => {
@@ -3701,6 +4818,7 @@
         addClickableIconsToPins(roundData.rounds, roundData.mapId, roundData.userscriptVersion);
       });
       window.addEventListener("urlchange", () => {
+        var _a2;
         clearMetaCache();
         if (currentObserver) {
           currentObserver.disconnect();
@@ -3710,16 +4828,17 @@
           currentPinObserver.disconnect();
           currentPinObserver = null;
         }
+        (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
       });
     });
   }
   function addMetaButtonsToRounds(rounds, mapId, userscriptVersion) {
     const roundItems = document.querySelectorAll(".result-list_listItemWrapper___XCGn");
     rounds.forEach((round, index2) => {
-      var _a;
+      var _a2;
       const roundItem = roundItems[index2];
       if (!roundItem) return;
-      const roundNumber = (_a = roundItem.querySelector(".result-list_roundNumber__RlIKm")) == null ? void 0 : _a.textContent;
+      const roundNumber = (_a2 = roundItem.querySelector(".result-list_roundNumber__RlIKm")) == null ? void 0 : _a2.textContent;
       if (roundNumber === "Total") return;
       if (roundItem.querySelector(".geometa-meta-btn")) return;
       const metaButton = document.createElement("button");
@@ -3762,8 +4881,8 @@
     currentPinObserver = new MutationObserver(() => {
       const pins = document.querySelectorAll('[class*="map-pin_mapPin"]');
       pins.forEach((pin) => {
-        var _a;
-        const pinText = (_a = pin.textContent) == null ? void 0 : _a.trim();
+        var _a2;
+        const pinText = (_a2 = pin.textContent) == null ? void 0 : _a2.trim();
         const roundNumber = parseInt(pinText || "");
         if (roundNumber >= 1 && roundNumber <= 5 && !pin.hasAttribute("data-geometa-pin-processed")) {
           pin.setAttribute("data-geometa-pin-processed", "true");
@@ -3796,7 +4915,8 @@
   function initLiveChallenge() {
     logInfo("live challenge support enabled");
     let pinChanged = false;
-    const observer = new MutationObserver(async (mutations) => {
+    const observer = new MutationObserver(async () => {
+      var _a2;
       if (!document.querySelector("[class*=result-map_roundPin]")) {
         pinChanged = false;
         return;
@@ -3805,12 +4925,13 @@
         return;
       }
       pinChanged = true;
+      (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
       const challengeId = getChallengeId();
       if (challengeId) {
         const { mapId, panoId } = await getChallengeInfo(challengeId);
         const mapInfo = await getMapInfo(mapId, false);
         if (!mapInfo.mapFound) return;
-        waitForElement("[class*=game_container]").then((container) => {
+        waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
           if (!container) {
             return;
           }
@@ -3828,6 +4949,7 @@
               source: "liveChallenge"
             }
           });
+          mountHintPanel(container);
         });
       }
     });
@@ -3836,6 +4958,11 @@
     } else {
       console.error("document.body is not available.");
     }
+    window.addEventListener("urlchange", () => {
+      var _a2;
+      observer.disconnect();
+      (_a2 = document.getElementById("geometa-hints")) == null ? void 0 : _a2.remove();
+    });
   }
   function initURLChangeEvent() {
     overrideHistoryMethod("pushState");
@@ -3852,7 +4979,7 @@
       return result;
     };
   }
-  var root$2 = /* @__PURE__ */ template(`<div class="geometa-map-label-container svelte-1mmcvqu"><p class="svelte-1mmcvqu">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1mmcvqu">Meta List</button></a></div>`);
+  var root$2 = /* @__PURE__ */ from_html(`<div class="geometa-map-label-container svelte-1mmcvqu"><p class="svelte-1mmcvqu">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1mmcvqu">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
     var div = root$2();
     var a = sibling(child(div), 2);
@@ -4052,23 +5179,25 @@
       css: (t) => `opacity: ${t * o}`
     };
   }
-  var root$1 = /* @__PURE__ */ template(`<div role="alert"><span class="toast-message svelte-1rq8lsd"> </span> <button class="toast-close-button svelte-1rq8lsd" aria-label="Close">×</button></div>`);
+  var root$1 = /* @__PURE__ */ from_html(`<div role="alert"><span class="toast-message svelte-1rq8lsd"> </span> <button class="toast-close-button svelte-1rq8lsd" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
     var div = root$1();
+    set_style(div, "", {}, {
+      position: "absolute",
+      top: "100%",
+      transform: "translateX(-75%) translateY(-10px)",
+      "margin-top": "10px"
+    });
     var span = child(div);
     var text = child(span);
     var button = sibling(span, 2);
     button.__click = function(...$$args) {
-      var _a;
-      (_a = $$props.onClose) == null ? void 0 : _a.apply(this, $$args);
+      var _a2;
+      (_a2 = $$props.onClose) == null ? void 0 : _a2.apply(this, $$args);
     };
     template_effect(() => {
-      set_class(div, `toast-notification toast-${type() ?? ""} svelte-1rq8lsd`);
-      set_style(div, "position", "absolute");
-      set_style(div, "top", "100%");
-      set_style(div, "transform", "translateX(-75%) translateY(-10px)");
-      set_style(div, "margin-top", "10px");
+      set_class(div, 1, `toast-notification toast-${type() ?? ""}`, "svelte-1rq8lsd");
       set_text(text, $$props.message);
     });
     transition(1, div, () => fade, () => ({ duration: 200, delay: 50 }));
@@ -4078,7 +5207,7 @@
   delegate(["click"]);
   async function handleUploadClick(_, isLoading, currentApiKey, getApiKeyFromGM, apiKeyInput, showApiKeyModal, performUpload) {
     if (get(isLoading)) return;
-    set(currentApiKey, proxy(getApiKeyFromGM()));
+    set(currentApiKey, getApiKeyFromGM(), true);
     if (!get(currentApiKey) || get(currentApiKey).trim() === "") {
       set(apiKeyInput, "");
       set(showApiKeyModal, true);
@@ -4090,7 +5219,7 @@
     const trimmedKey = get(apiKeyInput).trim();
     if (trimmedKey) {
       saveApiKeyToGM(trimmedKey);
-      set(currentApiKey, proxy(trimmedKey));
+      set(currentApiKey, trimmedKey, true);
       set(showApiKeyModal, false);
       showCustomToast("API Key saved!", "success", 2e3);
       performUpload(trimmedKey);
@@ -4102,30 +5231,34 @@
     set(showApiKeyModal, false);
     set(apiKeyInput, "");
   }
-  var root_1 = /* @__PURE__ */ template(`<div class="modal-overlay svelte-17or0cf" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-17or0cf"><h2 id="apiKeyModalTitle" class="svelte-17or0cf">Enter LearnableMeta API Key</h2> <p class="svelte-17or0cf">An API key is required to upload locations. Please paste your key below.</p> <p class="svelte-17or0cf">You can generate your API token by visiting <a target="_blank" rel="noopener noreferrer" class="svelte-17or0cf">profile page</a> on LearnableMeta and generating it there.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-17or0cf"> <div class="modal-actions svelte-17or0cf"><button class="modal-button modal-button-save svelte-17or0cf">Save & Upload</button> <button class="modal-button modal-button-cancel svelte-17or0cf">Cancel</button></div> <p class="modal-note svelte-17or0cf">Your API key will be stored securely in your browser's userscript storage for future
+  var root_1 = /* @__PURE__ */ from_html(`<div class="modal-overlay svelte-17or0cf" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-17or0cf"><h2 id="apiKeyModalTitle" class="svelte-17or0cf">Enter LearnableMeta API Key</h2> <p class="svelte-17or0cf">An API key is required to upload locations. Please paste your key below.</p> <p class="svelte-17or0cf">You can generate your API token by visiting <a target="_blank" rel="noopener noreferrer" class="svelte-17or0cf">profile page</a> on LearnableMeta and generating it there.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-17or0cf"/> <div class="modal-actions svelte-17or0cf"><button class="modal-button modal-button-save svelte-17or0cf">Save & Upload</button> <button class="modal-button modal-button-cancel svelte-17or0cf">Cancel</button></div> <p class="modal-note svelte-17or0cf">Your API key will be stored securely in your browser's userscript storage for future
         use.</p></div></div>`);
-  var root = /* @__PURE__ */ template(`<div class="upload-label-container"><button class="button_button__aR6_e button_sizeSmall__MB_qj custom-yellow-button svelte-17or0cf"> </button></div> <!> <!>`, 1);
+  var root = /* @__PURE__ */ from_html(`<div class="upload-label-container"><button class="button_button__aR6_e button_sizeSmall__MB_qj custom-yellow-button svelte-17or0cf"> </button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
     const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
-    let showApiKeyModal = state(false);
-    let apiKeyInput = state("");
-    let currentApiKey = state(null);
-    let isLoading = state(false);
-    let toastState = state(null);
-    let toastTimer = state(void 0);
+    let showApiKeyModal = /* @__PURE__ */ state(false);
+    let apiKeyInput = /* @__PURE__ */ state("");
+    let currentApiKey = /* @__PURE__ */ state(null);
+    let isLoading = /* @__PURE__ */ state(false);
+    let toastState = /* @__PURE__ */ state(null);
+    let toastTimer = /* @__PURE__ */ state(void 0);
     function showCustomToast(message, type = "info", duration = 3e3) {
       clearTimeout(get(toastTimer));
       const displayToast = () => {
-        set(toastState, proxy({ message, type }));
+        set(toastState, { message, type }, true);
         if (duration > 0) {
-          set(toastTimer, proxy(setTimeout(
-            () => {
-              hideCustomToast();
-            },
-            duration
-          )));
+          set(
+            toastTimer,
+            setTimeout(
+              () => {
+                hideCustomToast();
+              },
+              duration
+            ),
+            true
+          );
         }
       };
       if (get(toastState)) {
@@ -4157,14 +5290,14 @@
       }
     }
     onMount(() => {
-      set(currentApiKey, proxy(getApiKeyFromGM()));
+      set(currentApiKey, getApiKeyFromGM(), true);
       if (typeof _GM_registerMenuCommand === "function") {
         _GM_registerMenuCommand("LearnableMeta - Set/Update API Key", () => {
           set(currentApiKey, null);
           const newKey = prompt("Enter your new LearnableMeta API Key:");
           if (newKey && newKey.trim() !== "") {
             saveApiKeyToGM(newKey.trim());
-            set(currentApiKey, proxy(newKey.trim()));
+            set(currentApiKey, newKey.trim(), true);
             showCustomToast("LearnableMeta API Key updated!", "success");
           } else if (newKey !== null) {
             showCustomToast("API Key not updated (empty value provided).", "info");
@@ -4218,45 +5351,51 @@
     ];
     var text = child(button);
     var node = sibling(div, 2);
-    if_block(node, () => get(showApiKeyModal), ($$anchor2) => {
-      var div_1 = root_1();
-      var div_2 = child(div_1);
-      var p = sibling(child(div_2), 4);
-      var a = sibling(child(p));
-      set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
-      var input = sibling(p, 2);
-      var div_3 = sibling(input, 2);
-      var button_1 = child(div_3);
-      button_1.__click = [
-        handleSaveApiKey,
-        apiKeyInput,
-        saveApiKeyToGM,
-        currentApiKey,
-        showApiKeyModal,
-        showCustomToast,
-        performUpload
-      ];
-      var button_2 = sibling(button_1, 2);
-      button_2.__click = [
-        handleCancelModal,
-        showApiKeyModal,
-        apiKeyInput
-      ];
-      bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
-      append($$anchor2, div_1);
-    });
-    var node_1 = sibling(node, 2);
-    if_block(node_1, () => get(toastState), ($$anchor2) => {
-      ToastNotification($$anchor2, {
-        get message() {
-          return get(toastState).message;
-        },
-        get type() {
-          return get(toastState).type;
-        },
-        onClose: hideCustomToast
+    {
+      var consequent = ($$anchor2) => {
+        var div_1 = root_1();
+        var div_2 = child(div_1);
+        var p = sibling(child(div_2), 4);
+        var a = sibling(child(p));
+        set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
+        var input = sibling(p, 2);
+        var div_3 = sibling(input, 2);
+        var button_1 = child(div_3);
+        button_1.__click = [
+          handleSaveApiKey,
+          apiKeyInput,
+          saveApiKeyToGM,
+          currentApiKey,
+          showApiKeyModal,
+          showCustomToast,
+          performUpload
+        ];
+        var button_2 = sibling(button_1, 2);
+        button_2.__click = [handleCancelModal, showApiKeyModal, apiKeyInput];
+        bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
+        append($$anchor2, div_1);
+      };
+      if_block(node, ($$render) => {
+        if (get(showApiKeyModal)) $$render(consequent);
       });
-    });
+    }
+    var node_1 = sibling(node, 2);
+    {
+      var consequent_1 = ($$anchor2) => {
+        ToastNotification($$anchor2, {
+          get message() {
+            return get(toastState).message;
+          },
+          get type() {
+            return get(toastState).type;
+          },
+          onClose: hideCustomToast
+        });
+      };
+      if_block(node_1, ($$render) => {
+        if (get(toastState)) $$render(consequent_1);
+      });
+    }
     template_effect(() => {
       button.disabled = get(isLoading);
       set_text(text, get(isLoading) ? "Uploading..." : "LearnableMeta - Upload");
@@ -4277,12 +5416,12 @@
   }
   const containerId = "geometa-locations-upload";
   async function addLocationsUploadButtons() {
-    var _a;
+    var _a2;
     const mapId = extractMapIdFromMapMakerUrl(window.location.href);
     if (!mapId) {
       return;
     }
-    (_a = document.getElementById(containerId)) == null ? void 0 : _a.remove();
+    (_a2 = document.getElementById(containerId)) == null ? void 0 : _a2.remove();
     const mapInfo = await getMapInfo(mapId, true);
     if (!(mapInfo == null ? void 0 : mapInfo.mapFound)) {
       return;

--- a/userscript/src/lib/components/HintPanel.svelte
+++ b/userscript/src/lib/components/HintPanel.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { GM_xmlhttpRequest } from '$';
+  const SUPABASE_URL = 'https://kacuunztbvznzhfsyfgp.supabase.co';
+  const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImthY3V1bnp0YnZ6bnpoZnN5ZmdwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQxODY0NjEsImV4cCI6MjA2OTc2MjQ2MX0.VsC1HLOG413lXABUn4Sfv9c_arN06IxH9EXIdn-fzj4';
+
+  let country = '';
+  let meta_type = '';
+  let description = '';
+  let image_url = '';
+  let error = '';
+
+  const metaTypes = ['bollard', 'car', 'sign', 'language', 'generation', 'antenna', 'coverage'];
+
+  onMount(() => {
+    detectCountry();
+    detectMetaType();
+    detectImage();
+  });
+
+  function detectCountry() {
+    const flag = document.querySelector('[class*="result-layout_flag"] img, img.flag');
+    const alt = flag?.getAttribute('alt')?.trim();
+    if (alt) {
+      country = alt;
+    }
+  }
+
+  function detectMetaType() {
+    const note = document.querySelector('.geometa-note')?.textContent?.toLowerCase() || '';
+    const found = metaTypes.find((t) => note.includes(t));
+    if (found) {
+      meta_type = found;
+    }
+  }
+
+  function detectImage() {
+    const img = document.querySelector('[class*="result-layout_root"] img.responsive-image');
+    image_url = img?.getAttribute('src') || '';
+  }
+
+  function gmRequest(options: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      GM_xmlhttpRequest({
+        ...options,
+        onload: resolve,
+        onerror: reject
+      });
+    });
+  }
+
+  async function submit() {
+    try {
+      detectImage();
+      const res = await gmRequest({
+        method: 'POST',
+        url: `${SUPABASE_URL}/rest/v1/hints`,
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        data: JSON.stringify({ country, meta_type, description, image_url })
+      });
+      if (res.status >= 200 && res.status < 300) {
+        country = '';
+        meta_type = '';
+        description = '';
+        image_url = '';
+        error = '';
+      } else {
+        error = 'Failed to submit';
+      }
+    } catch (e) {
+      error = 'Failed to submit';
+    }
+  }
+</script>
+
+<style>
+  .hint-panel {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background: #444;
+    color: #fff;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    z-index: 9999;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    max-width: 300px;
+  }
+  .hint-panel input,
+  .hint-panel textarea {
+    width: 100%;
+    margin-bottom: 0.25rem;
+    color: #000;
+    background: #fff;
+  }
+  .hint-panel .error {
+    color: #f88;
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+  }
+  .hint-panel header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.25rem;
+  }
+  .hint-panel button.close {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #fff;
+  }
+</style>
+
+<div class="hint-panel">
+  <header>
+    <strong>Hint</strong>
+    <button class="close" on:click={() => (document.getElementById('geometa-hints')?.remove())}>×</button>
+  </header>
+  <div>
+    <label>Country <input bind:value={country} on:keydown|stopPropagation /></label>
+  </div>
+  <div>
+    <label>Meta type <input bind:value={meta_type} on:keydown|stopPropagation /></label>
+  </div>
+  <div>
+    <label>Description <textarea rows="2" bind:value={description} on:keydown|stopPropagation></textarea></label>
+  </div>
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
+  <button on:click={submit}>Submit</button>
+</div>

--- a/userscript/src/lib/hintPanel.ts
+++ b/userscript/src/lib/hintPanel.ts
@@ -1,0 +1,13 @@
+import { mount } from 'svelte';
+import HintPanel from './components/HintPanel.svelte';
+
+export function mountHintPanel(container: Element) {
+  const existing = document.getElementById('geometa-hints');
+  if (existing) {
+    existing.remove();
+  }
+  const element = document.createElement('div');
+  element.id = 'geometa-hints';
+  container.appendChild(element);
+  mount(HintPanel, { target: element });
+}

--- a/userscript/src/lib/liveChallenge.ts
+++ b/userscript/src/lib/liveChallenge.ts
@@ -1,11 +1,12 @@
 import { mount } from "svelte";
 import { getChallengeId, getChallengeInfo, getMapInfo, logInfo, waitForElement } from "./utils/main";
 import App from './App.svelte';
+import { mountHintPanel } from './hintPanel';
 
 export function initLiveChallenge() {
   logInfo('live challenge support enabled');
   let pinChanged = false;
-  const observer = new MutationObserver(async (mutations) => {
+  const observer = new MutationObserver(async () => {
     if (!document.querySelector('[class*=result-map_roundPin]')) {
       pinChanged = false;
       return;
@@ -14,12 +15,13 @@ export function initLiveChallenge() {
       return;
     }
     pinChanged = true;
+    document.getElementById('geometa-hints')?.remove();
     const challengeId = getChallengeId();
     if (challengeId) {
       const { mapId, panoId } = await getChallengeInfo(challengeId);
       const mapInfo = await getMapInfo(mapId, false);
       if (!mapInfo.mapFound) return;
-      waitForElement('[class*=game_container]').then((container) => {
+      waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
         if (!container) {
           return;
         }
@@ -37,6 +39,7 @@ export function initLiveChallenge() {
             source: 'liveChallenge'
           }
         });
+        mountHintPanel(container);
       });
     }
   });
@@ -46,4 +49,9 @@ export function initLiveChallenge() {
   } else {
     console.error('document.body is not available.');
   }
+
+  window.addEventListener('urlchange', () => {
+    observer.disconnect();
+    document.getElementById('geometa-hints')?.remove();
+  });
 }

--- a/userscript/src/lib/singlePlayer.ts
+++ b/userscript/src/lib/singlePlayer.ts
@@ -2,6 +2,7 @@ import { getMapInfo, logInfo, waitForElement } from './utils/main';
 import { mount } from 'svelte';
 import App from './App.svelte';
 import { unsafeWindow } from '$';
+import { mountHintPanel } from './hintPanel';
 
 //@ts-ignore
 const GeoGuessrEventFramework = unsafeWindow.GeoGuessrEventFramework;
@@ -45,6 +46,7 @@ export function initSinglePlayer() {
     });
     GeoGuessrEventFramework.events.addEventListener('round_end', async (event: GGEvent) => {
       document.getElementById('geometa-summary')?.remove();
+      document.getElementById('geometa-hints')?.remove();
 
       const mapInfo = await getMapInfo(event.detail.map.id, false);
       if (!mapInfo.mapFound) {
@@ -52,7 +54,7 @@ export function initSinglePlayer() {
         return;
       }
       logInfo('waiting for the result view to render');
-      waitForElement('div[data-qa="result-view-top"]').then((container) => {
+      waitForElement('[class*=result-layout_root__], div[data-qa="result-view-top"]').then((container) => {
         if (!container) {
           return;
         }
@@ -72,6 +74,7 @@ export function initSinglePlayer() {
             source: (window.location.href.includes('challenge') ? 'challenge' : 'map')
           }
         });
+        mountHintPanel(container);
       });
     });
     GeoGuessrEventFramework.events.addEventListener('game_end', async (event: GGEvent) => {
@@ -127,6 +130,7 @@ export function initSinglePlayer() {
         currentPinObserver.disconnect();
         currentPinObserver = null;
       }
+      document.getElementById('geometa-hints')?.remove();
     });
   });
 }

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         name: 'GeoGuessr Learnable Meta',
         description: 'UserScript for GeoGuessr Learnable Meta maps',
         match: ['*://*.geoguessr.com/*'],
-        connect: ['learnablemeta.com'],
+        connect: ['learnablemeta.com', 'kacuunztbvznzhfsyfgp.supabase.co'],
         updateURL: 'https://github.com/likeon/geometa/raw/main/dist/geometa.user.js',
         downloadURL: 'https://github.com/likeon/geometa/raw/main/dist/geometa.user.js',
         'run-at': 'document-start',


### PR DESCRIPTION
## Summary
- capture result image URL from the results screen and send it with hint submissions
- remove panel data after successful submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68911e45529483279055c3642a2067fd