### PR TITLE
Check for existing hints before submit

### DIFF
--- a/apps/api/src/lib/db/migrations/0032_unique_hints_image_url.sql
+++ b/apps/api/src/lib/db/migrations/0032_unique_hints_image_url.sql
@@ -1,0 +1,4 @@
+-- Ensure hints image_url values are unique
+ALTER TABLE hints
+ADD CONSTRAINT hints_image_url_unique UNIQUE (image_url);
+

--- a/apps/frontend/src/routes/(public)/about/+page.svelte
+++ b/apps/frontend/src/routes/(public)/about/+page.svelte
@@ -72,13 +72,13 @@
             ><strong class="font-semibold text-foreground">Install the Userscript.</strong>
             Once you have the extension installed, you can install the userscript by clicking
             <a
-              href="https://github.com/likeon/geometa/raw/main/dist/geometa.user.js"
+              href="https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js"
               target="_blank">this link</a
             >. Make sure to open new window with geoguessr after installing the script for first
             time.
             <p>
               The userscript is open-source and <a
-                href="https://github.com/likeon/geometa"
+                href="https://github.com/Zee-Cleanroom/geometa"
                 target="_blank">available on GitHub</a
               >.
             </p>

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -4655,6 +4655,19 @@
     async function submit() {
       try {
         detectImage();
+        const checkRes = await gmRequest({
+          method: "GET",
+          url: `${SUPABASE_URL}/rest/v1/hints?select=id&image_url=eq.${encodeURIComponent(image_url)}`,
+          headers: {
+            apikey: SUPABASE_KEY,
+            Authorization: `Bearer ${SUPABASE_KEY}`
+          }
+        });
+        const existing = JSON.parse(checkRes.responseText);
+        if (existing.length > 0) {
+          set(error, "Hint already exists for this image URL");
+          return;
+        }
         const res = await gmRequest({
           method: "POST",
           url: `${SUPABASE_URL}/rest/v1/hints`,

--- a/userscript/README.md
+++ b/userscript/README.md
@@ -2,7 +2,7 @@ UserScript for [GeoGuessr Learnable Meta maps](https://learnablemeta.com/)
 
 ## Installation
 0. Install Tampermonkey browser extension for [Chrome](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Firefox](https://addons.mozilla.org/firefox/addon/tampermonkey?utm_source=usz)
-1. [Click this link](https://github.com/likeon/geometa/raw/main/dist/geometa.user.js)
+1. [Click this link](https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js)
 
 ## Shoutout
 Big thanks to @miraclewhips for [geoguessr-event-framework](https://github.com/miraclewhips/geoguessr-event-framework).

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -5,8 +5,8 @@
 // @author       monkey
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
-// @downloadURL  https://github.com/likeon/geometa/raw/main/dist/geometa.user.js
-// @updateURL    https://github.com/likeon/geometa/raw/main/dist/geometa.user.js
+// @downloadURL  https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js
+// @updateURL    https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js
 // @match        *://*.geoguessr.com/*
 // @require      https://raw.githubusercontent.com/miraclewhips/geoguessr-event-framework/5e449d6b64c828fce5d2915772d61c7f95263e34/geoguessr-event-framework.js
 // @connect      learnablemeta.com
@@ -4655,6 +4655,19 @@
     async function submit() {
       try {
         detectImage();
+        const checkRes = await gmRequest({
+          method: "GET",
+          url: `${SUPABASE_URL}/rest/v1/hints?select=id&image_url=eq.${encodeURIComponent(image_url)}`,
+          headers: {
+            apikey: SUPABASE_KEY,
+            Authorization: `Bearer ${SUPABASE_KEY}`
+          }
+        });
+        const existing = JSON.parse(checkRes.responseText);
+        if (existing.length > 0) {
+          set(error, "Hint already exists for this image URL");
+          return;
+        }
         const res = await gmRequest({
           method: "POST",
           url: `${SUPABASE_URL}/rest/v1/hints`,

--- a/userscript/src/lib/components/HintPanel.svelte
+++ b/userscript/src/lib/components/HintPanel.svelte
@@ -52,6 +52,19 @@
   async function submit() {
     try {
       detectImage();
+      const checkRes = await gmRequest({
+        method: 'GET',
+        url: `${SUPABASE_URL}/rest/v1/hints?select=id&image_url=eq.${encodeURIComponent(image_url)}`,
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`
+        }
+      });
+      const existing = JSON.parse(checkRes.responseText);
+      if (existing.length > 0) {
+        error = 'Hint already exists for this image URL';
+        return;
+      }
       const res = await gmRequest({
         method: 'POST',
         url: `${SUPABASE_URL}/rest/v1/hints`,

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
         description: 'UserScript for GeoGuessr Learnable Meta maps',
         match: ['*://*.geoguessr.com/*'],
         connect: ['learnablemeta.com', 'kacuunztbvznzhfsyfgp.supabase.co'],
-        updateURL: 'https://github.com/likeon/geometa/raw/main/dist/geometa.user.js',
-        downloadURL: 'https://github.com/likeon/geometa/raw/main/dist/geometa.user.js',
+        updateURL: 'https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js',
+        downloadURL: 'https://github.com/Zee-Cleanroom/geometa/raw/main/dist/geometa.user.js',
         'run-at': 'document-start',
         require: [
           'https://raw.githubusercontent.com/miraclewhips/geoguessr-event-framework/5e449d6b64c828fce5d2915772d61c7f95263e34/geoguessr-event-framework.js'


### PR DESCRIPTION
## Summary
- prevent duplicate hints: check Supabase for existing image URL before posting
- add SQL migration enforcing unique image_url in hints table
- point userscript download/update URLs to the Zee-Cleanroom repository

## Testing
- `npm --prefix userscript run check`
- `npm --prefix userscript run build`
- `npm --prefix apps/frontend run lint` *(fails: code style issues in many files)*
- `npm --prefix apps/frontend run check` *(fails: type errors in existing files)*
- `npm --prefix apps/api run lint` *(fails: lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6892a56757f883278c9784462c575068