### PR TITLE
fix: delay hint autofill until meta ready

### DIFF
--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -5224,16 +5224,36 @@
     });
     onMount(async () => {
       await tick();
-      setTimeout(
-        () => {
-          detectDescription();
-          detectCountry();
-          detectMetaType();
-          detectImage();
-        },
-        0
-      );
+      requestAnimationFrame(() => {
+        setTimeout(
+          async () => {
+            await waitForMetaContent();
+            console.debug("[Autofill] Starting...");
+            detectDescription();
+            detectCountry();
+            detectMetaType();
+            detectImage();
+          },
+          0
+        );
+      });
     });
+    function waitForMetaContent() {
+      return new Promise((resolve) => {
+        const hasContent = () => document.querySelector("strong.svelte-a3mhc8") || document.querySelector(".geometa-note.svelte-a3mhc8") || document.querySelector('[class*="result-layout_root"] img.responsive-image');
+        if (hasContent()) {
+          resolve();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          if (hasContent()) {
+            observer.disconnect();
+            resolve();
+          }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    }
     function detectDescription() {
       var _a2, _b;
       set(description, ((_b = (_a2 = document.querySelector(".geometa-note")) == null ? void 0 : _a2.textContent) == null ? void 0 : _b.trim()) || "");

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -5224,16 +5224,36 @@
     });
     onMount(async () => {
       await tick();
-      setTimeout(
-        () => {
-          detectDescription();
-          detectCountry();
-          detectMetaType();
-          detectImage();
-        },
-        0
-      );
+      requestAnimationFrame(() => {
+        setTimeout(
+          async () => {
+            await waitForMetaContent();
+            console.debug("[Autofill] Starting...");
+            detectDescription();
+            detectCountry();
+            detectMetaType();
+            detectImage();
+          },
+          0
+        );
+      });
     });
+    function waitForMetaContent() {
+      return new Promise((resolve) => {
+        const hasContent = () => document.querySelector("strong.svelte-a3mhc8") || document.querySelector(".geometa-note.svelte-a3mhc8") || document.querySelector('[class*="result-layout_root"] img.responsive-image');
+        if (hasContent()) {
+          resolve();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          if (hasContent()) {
+            observer.disconnect();
+            resolve();
+          }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    }
     function detectDescription() {
       var _a2, _b;
       set(description, ((_b = (_a2 = document.querySelector(".geometa-note")) == null ? void 0 : _a2.textContent) == null ? void 0 : _b.trim()) || "");


### PR DESCRIPTION
## Summary
- run hint panel autofill only after panel and Learnable Meta content are fully rendered
- wait for meta content via mutation observer and log `[Autofill] Starting...`

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892eb47da008327aa8dc050bc2d7002